### PR TITLE
Consume and send services with related seed and demo data

### DIFF
--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- No copyright or license for configuration file, details here are not considered a creative work. -->
+
+<entity-facade-xml type="ext-demo">
+    <!-- Sftp server connection details for data import -->
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="FeedImportSftp"
+                                               description="SFTP server connection details for data import"
+                                               sendUrl="" username="" password=""/>
+    <!-- Shopify Connection Configuration -->
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="ShopifyConfig"
+                                               description="Shopify Connection Configuration"
+                                               sendUrl="https://${shopifyHost}/admin/api/${shopifyApiVersion}" username="" password=""
+                                               accessScopeEnumId=""/>
+
+    <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
+                                             description="Create OMS Fulfillment Feed System Message"
+                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+                                             receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
+                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+
+</entity-facade-xml>

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -24,4 +24,8 @@ under the License.
     <moqui.basic.Enumeration description="Shopify Shop Read Only Access" enumId="SHOP_READ_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
     <moqui.basic.Enumeration description="Shopify Shop Read and Write Access" enumId="SHOP_READ_WRITE_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
 
+    <!-- SystemMessageType data for Shopify Fulfillment -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="CreateShopifyFulfillment" description="Create Shopify Fulfillment System Message and Produce Ack System Message"
+                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ShopifyFulfillmentSystemMessage"/>
+
 </entity-facade-xml>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -17,7 +17,7 @@ under the License.
 -->
 
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://moqui.org/xsd/service-definition-3.xsd">
-    <service verb="get" noun="FulfillmentOrders">
+    <service verb="get" noun="FulfillmentOrders" authenticate="anonymous-all">
         <description>
             Get Fulfillment Orders for a given shopifyOrderId.
         </description>
@@ -42,35 +42,53 @@ under the License.
         </actions>
     </service>
 
-    <service verb="create" noun="Fulfillment">
+    <service verb="create" noun="Fulfillment" authenticate="anonymous-all">
         <description>
             Create a shopify fulfillment for given shopify line items and tracking number.
         </description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="shopifyOrderId" required="true"/>
-            <parameter name="trackingNumber" required="false"/>
+            <parameter name="trackingNumber"/>
+            <parameter name="trackingUrl"/>
+            <parameter name="carrier"/>
             <parameter name="lineItems" required="true" type="List">
                 <parameter name="shopifyLineItemId" required="true"/>
                 <parameter name="quantity" required="true"/>
             </parameter>
         </in-parameters>
+        <out-parameters>
+            <parameter name="shopifyFulfillmentId"/>
+        </out-parameters>
         <actions>
             <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentOrders" in-map="[shopifyOrderId:shopifyOrderId, systemMessageRemoteId:systemMessageRemoteId]" out-map="context"/>
 
+            <set field="aggregatedLineItemMap" from="[:]"/>
+            <iterate list="lineItems" entry="lineItem">
+                <if condition="aggregatedLineItemMap.get(lineItem.shopifyLineItemId) == null">
+                    <then>
+                        <script>aggregatedLineItemMap.put(lineItem.shopifyLineItemId, lineItem.quantity)</script>
+                    </then>
+                    <else>
+                        <script>aggregatedLineItemMap.put(lineItem.shopifyLineItemId, aggregatedLineItemMap.get(lineItem.shopifyLineItemId) + lineItem.quantity)</script>
+                    </else>
+                </if>
+            </iterate>
+
             <set field="lineItemsMapById" from="[:]"/>
             <iterate list="fulfillmentOrders" entry="fulfillmentOrder">
-                <set field="lineItems" from="fulfillmentOrder.line_items"/>
-                <iterate list="lineItems" entry="lineItem">
-                    <script>lineItemsMapById.put(lineItem.line_item_id, lineItem)</script>
+                <set field="fulfillmentOrderLineItems" from="fulfillmentOrder.line_items"/>
+                <iterate list="fulfillmentOrderLineItems" entry="fulfillmentOrderLineItem">
+                    <set field="lineItemId" from="fulfillmentOrderLineItem.line_item_id" type="String"/>
+                    <script>lineItemsMapById.put(lineItemId, fulfillmentOrderLineItem)</script>
                 </iterate>
             </iterate>
 
             <set field="fulfillmentItemsByFulfillmentOrderId" from="[:]"/>
-            <iterate list="lineItems" entry="lineItem">
-                <set field="lineItemMap" from="lineItemsMapById.get(lineItem.shopifyLineItemId)"/>
+            <iterate list="aggregatedLineItemMap" entry="quantity" key="shopifyLineItemId">
+                <set field="lineItemMap" from="lineItemsMapById.get(shopifyLineItemId)"/>
                 <script>
-                    org.moqui.util.CollectionUtilities.addToListInMap(lineItemMap.fulfillment_order_id, ["id": lineItemMap.id, "quantity": lineItem.quantity], fulfillmentItemsByFulfillmentOrderId)
+                    org.moqui.util.CollectionUtilities.addToListInMap(lineItemMap.fulfillment_order_id, ["id": lineItemMap.id, "quantity": quantity], fulfillmentItemsByFulfillmentOrderId)
                 </script>
             </iterate>
 
@@ -79,7 +97,7 @@ under the License.
                 <script>lineItemsByFulfillmentOrder.add(["fulfillment_order_id": fulfillmentOrderId, "fulfillment_order_line_items": lineItems])</script>
             </iterate>
 
-            <set field="requestBody" from="['fulfillment':['line_items_by_fulfillment_order':lineItemsByFulfillmentOrder, 'tracking_info':['number': trackingNumber]]]"/>
+            <set field="requestBody" from="['fulfillment':['line_items_by_fulfillment_order':lineItemsByFulfillmentOrder, 'tracking_info':['number': trackingNumber, 'company': carrier, 'url': trackingUrl]]]"/>
             <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, endPoint:'fulfillments.json',
                         requestType:'POST', contentType:'application/json', requestBody:requestBody]" out-map="createFulfillmentResponse"/>
 
@@ -88,7 +106,7 @@ under the License.
                     ${systemMessageRemoteId} sent error response ${createFulfillmentResponse.statusCode}: ${createFulfillmentResponse.response}"/>
             </if>
 
-            <log level="info" message="Fulfillments => ${createFulfillmentResponse.response}"/>
+            <set field="shopifyFulfillmentId" from="createFulfillmentResponse.response.fulfillment.id"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://moqui.org/xsd/service-definition-3.xsd">
+    <service verb="consume" noun="FulfillmentFeed" authenticate="anonymous-all">
+        <description>
+            Consume Fulfillment Feed JSON System Message and produce 'CreateShopifyFulfillment' System Message for each record.
+        </description>
+        <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+        <actions>
+            <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage">
+                <field-map field-name="systemMessageId"/>
+            </entity-find-one>
+
+            <set field="shipments" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, List.class)"/>
+            <iterate list="shipments" entry="shipment">
+                <set field="messageText" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(shipment)"/>
+                <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage" in-map="[systemMessageTypeId:'CreateShopifyFulfillment', systemMessageRemoteId:'ShopifyConfig', messageText:messageText, sendNow:true]"
+                              out-map="context" transaction="force-new"/>
+            </iterate>
+        </actions>
+    </service>
+    <service verb="send" noun="ShopifyFulfillmentSystemMessage" authenticate="anonymous-all">
+        <description>
+            Send service to invoke Create Shopify Fulfillment API for the System Message.
+        </description>
+        <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
+        <actions>
+            <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage">
+                <field-map field-name="systemMessageId"/>
+            </entity-find-one>
+
+            <set field="shipment" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
+            <set field="lineItems" from="[]"/>
+            <iterate list="shipment.shipmentItems" entry="shipmentItem">
+                <set field="lineItem" from="[:]"/>
+                <set field="lineItem.shopifyLineItemId" from="shipmentItem.shopifyOrderLineId"/>
+                <set field="lineItem.quantity" from="shipmentItem.quantity"/>
+                <script>lineItems.add(lineItem)</script>
+            </iterate>
+
+            <set field="fulfillmentContext" from="[:]"/>
+            <set field="fulfillmentContext.lineItems" from="lineItems"/>
+            <set field="fulfillmentContext.shopifyOrderId" from="shipment.shopifyOrderId"/>
+            <set field="fulfillmentContext.trackingNumber" from="shipment.trackingNumber"/>
+            <set field="fulfillmentContext.trackingUrl" from="shipment.trackingUrl"/>
+            <set field="fulfillmentContext.carrier" from="shipment.carrierPartyId"/>
+            <set field="fulfillmentContext.systemMessageRemoteId" from="systemMessage.systemMessageRemoteId"/>
+            <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.create#Fulfillment" in-map="fulfillmentContext" out-map="outMap"/>
+
+            <set field="remoteMessageId" from="outMap.shopifyFulfillmentId"/>
+        </actions>
+    </service>
+</services>


### PR DESCRIPTION
1) Consume service to consume OMS fulfillment feed. 2) Send service to invoke create shopify fulfillment API. 3) Some improvements in create shopify fulfillment servcice including aggregation of shopify line item quantity by id. 4) Related seed and demo data.