### PR TITLE
Added: Used sendPath for configurable directory paths for OMSFulfillmentFeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Make sure to setup following configuration data with respect to your environment
 
 ```aidl
 <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
-<!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use 
-     some other directory then please change the value of 'mantle.content.root' preferenceKey -->
+<!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory. 
+     For using any other directory update the value of mantle.content.root preferenceKey -->
 <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
                                          description="Create OMS Fulfillment Feed System Message"
                                          parentTypeId="LocalFeedFile"

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ Make sure to setup following configuration data with respect to your environment
                                            accessScopeEnumId="SHOP_READ_WRITE_ACCESS"/>
 
 <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
+<!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use 
+     some other directory then please change the value of 'mantle.content.root' preferenceKey -->
 <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
                                          description="Create OMS Fulfillment Feed System Message"
                                          consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
                                          receivePath="" receiveFilePattern=""
-                                         receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+                                         receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+                                         sendPath=""/>
 
 <!-- SystemMessageType record for sending Shopify Fulfillment Ack Feed (sendPath = sftp directory) -->
 <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Make sure to setup following configuration data with respect to your environment
                                          description="Create OMS Fulfillment Feed System Message"
                                          parentTypeId="LocalFeedFile"
                                          consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-                                         receivePath="" receiveFilePattern=""
+                                         receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
                                          receiveResponseEnumId="MsgRrMove" receiveMovePath=""
-                                         sendPath=""/>
+                                         sendPath="${contentRoot}/Shopify/OMSFulfillmentFeed"/>
 
 <!-- SystemMessageType record for sending Shopify Fulfillment Ack Feed (sendPath = sftp directory) -->
 <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -16,10 +16,10 @@
     <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
          some other directory then please change the value of 'mantle.content.root' preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
-                                             description="Create OMS Fulfillment Feed System Message"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-                                             receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
-                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""
-                                             sendPath="/Shopify/OMSFulfillmentFeed"/>
+            description="Create OMS Fulfillment Feed System Message"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+            receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
+            receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+            sendPath="${contentRoot}/Shopify/OMSFulfillmentFeed"/>
 
 </entity-facade-xml>

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -4,13 +4,13 @@
 <entity-facade-xml type="ext-demo">
     <!-- Sftp server connection details for data import -->
     <moqui.service.message.SystemMessageRemote systemMessageRemoteId="FeedImportSftp"
-                                               description="SFTP server connection details for data import"
-                                               sendUrl="" username="" password=""/>
+            description="SFTP server connection details for data import"
+            sendUrl="" username="" password=""/>
     <!-- Shopify Connection Configuration -->
     <moqui.service.message.SystemMessageRemote systemMessageRemoteId="ShopifyConfig"
-                                               description="Shopify Connection Configuration"
-                                               sendUrl="https://${shopifyHost}/admin/api/${shopifyApiVersion}" username="" password=""
-                                               accessScopeEnumId=""/>
+            description="Shopify Connection Configuration"
+            sendUrl="https://${shopifyHost}/admin/api/${shopifyApiVersion}" username="" password=""
+            accessScopeEnumId=""/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
     <!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory.

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -13,8 +13,8 @@
                                                accessScopeEnumId=""/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
-    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
-         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
+    <!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory.
+         For using any other directory update the value of mantle.content.root preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
             description="Create OMS Fulfillment Feed System Message"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -18,8 +18,8 @@
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
                                              description="Create OMS Fulfillment Feed System Message"
                                              consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-                                             receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
+                                             receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
                                              receiveResponseEnumId="MsgRrMove" receiveMovePath=""
-                                             sendPath=""/>
+                                             sendPath="/Shopify/OMSFulfillmentFeed"/>
 
 </entity-facade-xml>

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -13,10 +13,13 @@
                                                accessScopeEnumId=""/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
+    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
+         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
                                              description="Create OMS Fulfillment Feed System Message"
                                              consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
                                              receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
-                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+                                             sendPath=""/>
 
 </entity-facade-xml>

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -29,8 +29,14 @@ under the License.
                                              sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ShopifyFulfillmentSystemMessage"/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
+    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
+         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
-                                             description="Create OMS Fulfillment Feed System Message"/>
+                                             description="Create OMS Fulfillment Feed System Message"
+                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+                                             receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
+                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+                                             sendPath=""/>
 
     <!-- SystemMessageType record for sending Shopify Fulfillment Ack Feed (sendPath = sftp directory) -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -46,8 +46,8 @@ under the License.
                                              sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ShopifyFulfillmentSystemMessage"/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
-    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
-         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
+    <!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory.
+         For using any other directory update the value of mantle.content.root preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
                                              description="Create OMS Fulfillment Feed System Message"
                                              parentTypeId="LocalFeedFile"

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -6,9 +6,9 @@
     <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
          some other directory then please change the value of 'mantle.content.root' preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
-                                             description="Create OMS Fulfillment Feed System Message"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-                                             receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
-                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""
-                                             sendPath=""/>
+            description="Create OMS Fulfillment Feed System Message"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+            receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
+            receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+            sendPath="${contentRoot}/Shopify/OMSFulfillmentFeed"/>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -3,8 +3,8 @@
 <entity-facade-xml type="ext-upgrade-upcoming">
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
-    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
-         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
+    <!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory.
+         For using any other directory update the value of mantle.content.root preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
             description="Create OMS Fulfillment Feed System Message"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<entity-facade-xml type="ext-upgrade-upcoming">
+
+    <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
+    <!-- Note: By default the 'sendPath' local directory structure is created in 'runtime://datamanager' directory. If you want to use
+         some other directory then please change the value of 'mantle.content.root' preferenceKey -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
+                                             description="Create OMS Fulfillment Feed System Message"
+                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+                                             receivePath="" receiveFilePattern=".*Fulfillment.*\.json"
+                                             receiveResponseEnumId="MsgRrMove" receiveMovePath=""
+                                             sendPath=""/>
+</entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -6,9 +6,5 @@
     <!-- Note: By default the sendPath local directory structure is created in runtime://datamanager directory.
          For using any other directory update the value of mantle.content.root preferenceKey -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
-            description="Create OMS Fulfillment Feed System Message"
-            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-            receivePath="/home/${sftpUsername}/hotwax/shopify/FulfilledOrderItems" receiveFilePattern=".*Fulfillment.*\.json"
-            receiveResponseEnumId="MsgRrMove" receiveMovePath=""
             sendPath="${contentRoot}/Shopify/OMSFulfillmentFeed"/>
 </entity-facade-xml>


### PR DESCRIPTION
Currently, 'receivePath' is used to specify the local directory structure of where the fetched file should be kept. This restricts our control to specify a separate file path which could be outside of Moqui also. 
So, I have added a field 'sendPath' in the 'SystemMessageType' data for 'OMSFulfillmentFeed' to specify the local directory structure.