### PR TITLE
Added: Used receivePath for configurable folder paths for ShopifyFulfillmentAckFeed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Make sure to setup following configuration data with respect to your environment
 <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"
                                          parentTypeId="LocalFeedFile"
                                          sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                         sendPath=""/>
+                                         sendPath=""
+                                         receivePath="${contentRoot}/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
 
 <!-- ServiceJob data for polling OMS Fulfilled Items Feed -->
 <moqui.service.job.ServiceJob jobName="poll_SystemMessageSftp_OMSFulfillmentFeed" description="Poll OMS Fulfilled Items Feed"

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -56,7 +56,8 @@ under the License.
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"
                                              parentTypeId="LocalFeedFile"
                                              sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+                                             sendPath=""
+                                             receivePath="${contentRoot}/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
 
     <!-- SystemMessageType record for importing Product Tags Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="ProductTagsFeed"

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -149,9 +149,22 @@ under the License.
                 <return message="No eligible records for Shopify Fulfillment Ack Feed at ${nowDate}, not generating the Shopify Fulfillment Ack file."/>
             </if>
 
-            <set field="contentRoot" from="ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager'"/>
+            <!-- Fetch the receivePath from SystemMessageType to prepare the path for creating the file in the receiving system. Ex: Moqui's datamanager directory in runtime for creating feeds.-->
+            <entity-find entity-name="moqui.service.message.SystemMessageType" list="systemMessageType">
+                <econdition field-name="systemMessageTypeId" value="SendShopifyFulfillmentAck"/>
+            </entity-find>
+            <if condition="systemMessageType == null"><return error="true" message="System Message Type ${systemMessageTypeId} does not exist."/></if>
+
+            <!-- Prepare Shopify Fulfillment Ack Feed File Path -->
+            <script><![CDATA[
+                String receivePath = ec.resource.expand(systemMessageType.first.receivePath, null,
+                        [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager',
+                        date:ec.l10n.format(nowDate, "yyyy-MM-dd"),
+                        dateTime:ec.l10n.format(nowDate, "yyyy-MM-dd-HH-mm-ss")], false)
+            ]]></script>
+
             <set field="jsonFileName" value="ShopifyFulfillmentFeed-${ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss', null, TimeZone.getDefault())}.json"/>
-            <set field="jsonFilePathRef" value="${contentRoot}/ShopifyFulfillmentAckFeed/${jsonFileName}"/>
+            <set field="jsonFilePathRef" value="${receivePath}"/>
             <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
 
             <script>


### PR DESCRIPTION
* Added the `receivePath` in the SystemMessageType's declared data, with `systemMessageTypeId` 'SendShopifyFulfillmentAck'.
* Also updated the way of preparing the **jsonFilePathRef** in feed generation using script.
* Initially we were preparing the **contentRoot** named variable in the feed services but now we will be preparing this with `receivePath` using script.
* Preserved **jsonFileName** variable for storing filename in system message's `remoteMessageId`, used for filename preparation for SFTP location.