### PR TITLE
Improved: Used receivePath for configurable folder paths for ShopifyFulfillmentAckFeed 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Make sure to setup following configuration data with respect to your environment
 <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"
                                          parentTypeId="LocalFeedFile"
                                          sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                         sendPath=""/>
+                                         sendPath=""
+                                         receivePath="${contentRoot}/shopify/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
 
 <!-- ServiceJob data for polling OMS Fulfilled Items Feed -->
 <moqui.service.job.ServiceJob jobName="poll_SystemMessageSftp_OMSFulfillmentFeed" description="Poll OMS Fulfilled Items Feed"

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -56,7 +56,8 @@ under the License.
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"
                                              parentTypeId="LocalFeedFile"
                                              sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+                                             sendPath=""
+                                             receivePath="${contentRoot}/shopify/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
 
     <!-- SystemMessageType record for importing Product Tags Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="ProductTagsFeed"

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -39,104 +39,119 @@ under the License.
     <moqui.basic.Enumeration description="Bulk Order Metafields Query" enumId="BulkOrderMetafieldsQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderMetafieldsQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
 
     <!-- Parent SystemMessageType record for incoming and outgoing local feed file system message types -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="LocalFeedFile" description="Local Feed File"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="LocalFeedFile"
+            description="Local Feed File"/>
 
     <!-- SystemMessageType record for creating Shopify Fulfillment -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="CreateShopifyFulfillment" description="Create Shopify Fulfillment System Message"
-                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ShopifyFulfillmentSystemMessage"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="CreateShopifyFulfillment"
+            description="Create Shopify Fulfillment System Message"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ShopifyFulfillmentSystemMessage"/>
 
     <!-- SystemMessageType record for importing OMS Fulfillment Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="OMSFulfillmentFeed"
-                                             description="Create OMS Fulfillment Feed System Message"
-                                             parentTypeId="LocalFeedFile"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
-                                             receivePath="" receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+            description="Create OMS Fulfillment Feed System Message"
+            parentTypeId="LocalFeedFile"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#FulfillmentFeed"
+            receivePath=""
+            receiveResponseEnumId="MsgRrMove"
+            receiveMovePath=""/>
 
     <!-- SystemMessageType record for sending Shopify Fulfillment Ack Feed (sendPath = sftp directory) -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck" description="Send Shopify Fulfillment Ack Feed"
-                                             parentTypeId="LocalFeedFile"
-                                             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""
-                                             receivePath="${contentRoot}/shopify/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck"
+            description="Send Shopify Fulfillment Ack Feed"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""
+            receivePath="${contentRoot}/shopify/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
 
     <!-- SystemMessageType record for importing Product Tags Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="ProductTagsFeed"
-                                             description="Create Product Tags Feed System Message"
-                                             parentTypeId="LocalFeedFile"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#GraphQLBulkImportFeed"
-                                             receivePath="" receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+            description="Create Product Tags Feed System Message"
+            parentTypeId="LocalFeedFile"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#GraphQLBulkImportFeed"
+            receivePath=""
+            receiveResponseEnumId="MsgRrMove"
+            receiveMovePath=""/>
 
     <!-- Parent SystemMessageType for all the shopify bulk import mutation system message types -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="ShopifyBulkImport" description="Parent SystemMessageType for Shopify Bulk Imports"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="ShopifyBulkImport"
+            description="Parent SystemMessageType for Shopify Bulk Imports"/>
 
     <!-- Parent SystemMessageType for all the shopify bulk query system message types -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="ShopifyBulkQuery" description="Parent SystemMessageType for Shopify Bulk Query"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="ShopifyBulkQuery"
+            description="Parent SystemMessageType for Shopify Bulk Query"/>
 
     <!-- SystemMessageType record for updating product tags in Shopify -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkUpdateProductTags" description="Create Update Product Tags System Message"
-                                             parentTypeId="ShopifyBulkImport"
-                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkMutationSystemMessage"
-                                             sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductTags.ftl"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
-                                             receivePath="${contentRoot}/shopify/ProductTagsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkUpdateProductTags"
+            description="Create Update Product Tags System Message"
+            parentTypeId="ShopifyBulkImport"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkMutationSystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductTags.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/ProductTagsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
 
     <!-- SystemMessageType record for sending bulk update product tags result to SFTP -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkUpdateProductTagsResult"
-                                             description="Send Bulk Update Product Tags Result"
-                                             parentTypeId="LocalFeedFile"
-                                             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+            description="Send Bulk Update Product Tags Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
 
     <!-- SystemMessageType record for importing Product Variants Feed -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="ProductVariantsFeed"
-                                             description="Create Product Variants Feed System Message"
-                                             parentTypeId="LocalFeedFile"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#GraphQLBulkImportFeed"
-                                             receivePath="" receiveResponseEnumId="MsgRrMove" receiveMovePath=""/>
+            description="Create Product Variants Feed System Message"
+            parentTypeId="LocalFeedFile"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#GraphQLBulkImportFeed"
+            receivePath=""
+            receiveResponseEnumId="MsgRrMove"
+            receiveMovePath=""/>
 
     <!-- SystemMessageType record for updating product variants in Shopify -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkUpdateProductVariants" description="Create Update Product Variants System Message"
-                                             parentTypeId="ShopifyBulkImport"
-                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkMutationSystemMessage"
-                                             sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductVariants.ftl"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
-                                             receivePath="${contentRoot}/shopify/ProductVariantsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkUpdateProductVariants"
+            description="Create Update Product Variants System Message"
+            parentTypeId="ShopifyBulkImport"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkMutationSystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductVariants.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/ProductVariantsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
 
     <!-- SystemMessageType record for sending bulk update product variants result to SFTP -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkUpdateProductVariantsResult"
-                                             description="Send Bulk Update Product Variants Result"
-                                             parentTypeId="LocalFeedFile"
-                                             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+            description="Send Bulk Update Product Variants Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
 
     <!-- SystemMessageType record for bulk variant metafield query to Shopify -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkVariantsMetafieldQuery" description="Bulk Variants Metafield Query System Message"
-                                             parentTypeId="ShopifyBulkQuery"
-                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
-                                             sendPath="component://shopify-connector/template/graphQL/BulkVariantsMetafieldQuery.ftl"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
-                                             receivePath="${contentRoot}/shopify/BulkVariantsMetafieldFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkVariantsMetafieldQuery"
+            description="Bulk Variants Metafield Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkVariantsMetafieldQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkVariantsMetafieldFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
 
     <!-- SystemMessageType record for sending bulk variants metafield query result to SFTP -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkVariantsMetafieldQueryResult"
-                                             description="Send Bulk Variants Metafield Query Result"
-                                             parentTypeId="LocalFeedFile"
-                                             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+            description="Send Bulk Variants Metafield Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
 
     <!-- SystemMessageType record for bulk order metafields query to Shopify -->
-    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderMetafieldsQuery" description="Bulk Order Metafields Query System Message"
-                                             parentTypeId="ShopifyBulkQuery"
-                                             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
-                                             sendPath="component://shopify-connector/template/graphQL/BulkOrderMetafieldsQuery.ftl"
-                                             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
-                                             receivePath="${contentRoot}/shopify/BulkOrderMetafieldsFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderMetafieldsQuery"
+            description="Bulk Order Metafields Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderMetafieldsQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderMetafieldsFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl"/>
 
     <!-- SystemMessageType record for sending bulk order metafields query result to SFTP -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderMetafieldsQueryResult"
-                                             description="Send Bulk Order Metafields Query Result"
-                                             parentTypeId="LocalFeedFile"
-                                             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                             sendPath=""/>
+            description="Send Bulk Order Metafields Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
 
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade-upcoming">
+
+    <!-- SystemMessageType record for sending Shopify Fulfillment Ack Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendShopifyFulfillmentAck"
+            receivePath="${contentRoot}/shopify/ShopifyFulfillmentAckFeed/ShopifyFulfillmentFeed-${dateTime}.json"/>
+
+</entity-facade-xml>
+

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -149,9 +149,22 @@ under the License.
                 <return message="No eligible records for Shopify Fulfillment Ack Feed at ${nowDate}, not generating the Shopify Fulfillment Ack file."/>
             </if>
 
-            <set field="contentRoot" from="ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager'"/>
+            <!-- Fetch the receivePath from SystemMessageType to prepare the path for creating the file in the receiving system. Ex: Moqui's datamanager directory in runtime for creating feeds.-->
+            <entity-find entity-name="moqui.service.message.SystemMessageType" list="systemMessageType">
+                <econdition field-name="systemMessageTypeId" value="SendShopifyFulfillmentAck"/>
+            </entity-find>
+            <if condition="systemMessageType == null"><return error="true" message="System Message Type ${systemMessageTypeId} does not exist."/></if>
+
+            <!-- Prepare Shopify Fulfillment Ack Feed File Path -->
+            <script><![CDATA[
+                String receivePath = ec.resource.expand(systemMessageType.first.receivePath, null,
+                        [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager',
+                        date:ec.l10n.format(nowDate, "yyyy-MM-dd"),
+                        dateTime:ec.l10n.format(nowDate, "yyyy-MM-dd-HH-mm-ss")], false)
+            ]]></script>
+
             <set field="jsonFileName" value="ShopifyFulfillmentFeed-${ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss', null, TimeZone.getDefault())}.json"/>
-            <set field="jsonFilePathRef" value="${contentRoot}/ShopifyFulfillmentAckFeed/${jsonFileName}"/>
+            <set field="jsonFilePathRef" value="${receivePath}"/>
             <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
 
             <script>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -153,7 +153,7 @@ under the License.
             <entity-find entity-name="moqui.service.message.SystemMessageType" list="systemMessageType">
                 <econdition field-name="systemMessageTypeId" value="SendShopifyFulfillmentAck"/>
             </entity-find>
-            <if condition="systemMessageType == null"><return error="true" message="System Message Type ${systemMessageTypeId} does not exist."/></if>
+            <if condition="systemMessageType == null"><return error="true" message="Could not find SystemMessageType with ID ${systemMessageTypeId}"/></if>
 
             <!-- Prepare Shopify Fulfillment Ack Feed File Path -->
             <!-- Using receivePath from SystemMessageType to prepare the jsonFilePathRef.-->

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -150,18 +150,17 @@ under the License.
             </if>
 
             <!-- Fetch the receivePath from SystemMessageType to prepare the path for creating the file in the receiving system. Ex: Moqui's datamanager directory in runtime for creating feeds.-->
-            <entity-find entity-name="moqui.service.message.SystemMessageType" list="systemMessageType">
-                <econdition field-name="systemMessageTypeId" value="SendShopifyFulfillmentAck"/>
-            </entity-find>
+            <entity-find-one entity-name="moqui.service.message.SystemMessageType" value-field="systemMessageType">
+                <field-map field-name="systemMessageTypeId" value="SendShopifyFulfillmentAck"/>
+            </entity-find-one>
             <if condition="systemMessageType == null"><return error="true" message="Could not find SystemMessageType with ID ${systemMessageTypeId}"/></if>
 
             <!-- Prepare Shopify Fulfillment Ack Feed File Path -->
             <!-- Using receivePath from SystemMessageType to prepare the jsonFilePathRef.-->
             <set field="jsonFilePathRef" from="ec.resource.expand(systemMessageType.receivePath, null,
-            [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', date:ec.l10n.format(nowDate, 'yyyy-MM-dd'), dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss'),
-             productStoreId:productStoreId], false)"/>
+            [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', date:ec.l10n.format(nowDate, 'yyyy-MM-dd'),
+            dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss')], false)"/>
             <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
-            <set field="jsonFileName" value="ShopifyFulfillmentFeed-${ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss', null, TimeZone.getDefault())}.json"/>
 
             <script>
                 import com.fasterxml.jackson.core.JsonGenerator
@@ -203,7 +202,7 @@ under the License.
 
             <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                           in-map="[systemMessageTypeId:'SendShopifyFulfillmentAck',
-                    systemMessageRemoteId:systemMessageRemoteId, messageText:jsonFilePathRef, remoteMessageId: jsonFileName, sendNow:true]"
+                    systemMessageRemoteId:systemMessageRemoteId, messageText:jsonFilePathRef, remoteMessageId: jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
                           out-map="shopifyFulfillmentAckOut"/>
 
             <if condition="jobName &amp;&amp; !skipLastRunTimeUpdate">

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -156,16 +156,12 @@ under the License.
             <if condition="systemMessageType == null"><return error="true" message="System Message Type ${systemMessageTypeId} does not exist."/></if>
 
             <!-- Prepare Shopify Fulfillment Ack Feed File Path -->
-            <script><![CDATA[
-                String receivePath = ec.resource.expand(systemMessageType.first.receivePath, null,
-                        [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager',
-                        date:ec.l10n.format(nowDate, "yyyy-MM-dd"),
-                        dateTime:ec.l10n.format(nowDate, "yyyy-MM-dd-HH-mm-ss")], false)
-            ]]></script>
-
-            <set field="jsonFileName" value="ShopifyFulfillmentFeed-${ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss', null, TimeZone.getDefault())}.json"/>
-            <set field="jsonFilePathRef" value="${receivePath}"/>
+            <!-- Using receivePath from SystemMessageType to prepare the jsonFilePathRef.-->
+            <set field="jsonFilePathRef" from="ec.resource.expand(systemMessageType.receivePath, null,
+            [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', date:ec.l10n.format(nowDate, 'yyyy-MM-dd'), dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss'),
+             productStoreId:productStoreId], false)"/>
             <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+            <set field="jsonFileName" value="ShopifyFulfillmentFeed-${ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss', null, TimeZone.getDefault())}.json"/>
 
             <script>
                 import com.fasterxml.jackson.core.JsonGenerator


### PR DESCRIPTION
* Added the `receivePath` in the SystemMessageType's declared data, with `systemMessageTypeId` 'SendShopifyFulfillmentAck'.
* Also updated the way of preparing the **jsonFilePathRef** in feed generation using script.
* Initially we were preparing the **contentRoot** named variable in the feed services but now we will be preparing this with `receivePath` using script.
* Added `shopify` named sub directory under receiving system i.e. Moqui's datamanager directory in runtime.
* Preserved **jsonFileName** variable for storing filename in system message's `remoteMessageId`, used for filename preparation for SFTP location.