### PR TITLE
Enhancements and improvements in shopify bulk import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,82 @@ You could configure following default parameters and any additional parameters a
 </moqui.service.job.ServiceJob>
 ```
 
+#### Bulk Order Headers Query
+
+```aidl
+    <!-- SystemMessageType record for bulk order headers query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderHeadersQuery"
+            description="Bulk Order Headers Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderHeadersQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderHeadersQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order headers query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderHeadersQueryResult"
+            description="Send Bulk Order Headers Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderHeadersQuery and SendBulkOrderHeadersQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Headers Query Result" enumId="SendBulkOrderHeadersQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Headers Query" enumId="BulkOrderHeadersQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderHeadersQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+    <!-- ServiceJob data for queuing bulk order headers query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderHeadersQuery" description="Queue bulk order headers query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderHeadersQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="fromDateLabel" parameterValue=""/>
+        <parameters parameterName="thruDateLabel" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+```
+
+### Bulk Order Items Query
+
+```aidl
+    <!-- SystemMessageType record for bulk order items query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderItemsQuery"
+            description="Bulk Order Items Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderItemsQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderItemsQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order items query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderItemsQueryResult"
+            description="Send Bulk Order Items Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderItemsQuery and SendBulkOrderItemsQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Items Query Result" enumId="SendBulkOrderItemsQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Items Query" enumId="BulkOrderItemsQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderItemsQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+    <!-- ServiceJob data for queuing bulk updated order items query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderItemsQuery" description="Queue bulk order items query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderItemsQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="fromDateLabel" parameterValue=""/>
+        <parameters parameterName="thruDateLabel" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+```
+
 ## Shopify Webhook Integration
 
 Set of services and configuration to integrate with Shopify Webhook GraphQL API.  

--- a/data/ShopifyServiceJobData.xml
+++ b/data/ShopifyServiceJobData.xml
@@ -105,4 +105,28 @@ under the License.
         <parameters parameterName="fromDate" parameterValue=""/>
         <parameters parameterName="thruDate" parameterValue=""/>
     </moqui.service.job.ServiceJob>
+
+    <!-- ServiceJob data for queuing bulk order headers query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderHeadersQuery" description="Queue bulk order headers query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderHeadersQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="fromDateLabel" parameterValue=""/>
+        <parameters parameterName="thruDateLabel" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+
+    <!-- ServiceJob data for queuing bulk updated order items query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderItemsQuery" description="Queue bulk order items query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderItemsQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="fromDateLabel" parameterValue=""/>
+        <parameters parameterName="thruDateLabel" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
 </entity-facade-xml>

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -93,7 +93,7 @@ under the License.
             sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductTags.ftl"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
             receivePath="${contentRoot}/shopify/ProductTagsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
-        <paramters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
     </moqui.service.message.SystemMessageType>
 
     <!-- SystemMessageType record for sending bulk update product tags result to SFTP -->
@@ -121,7 +121,7 @@ under the License.
             sendPath="component://shopify-connector/template/graphQL/BulkUpdateProductVariants.ftl"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
             receivePath="${contentRoot}/shopify/ProductVariantsFeed/result/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
-        <paramters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
     </moqui.service.message.SystemMessageType>
 
     <!-- SystemMessageType record for sending bulk update product variants result to SFTP -->
@@ -139,7 +139,7 @@ under the License.
             sendPath="component://shopify-connector/template/graphQL/BulkVariantsMetafieldQuery.ftl"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
             receivePath="${contentRoot}/shopify/BulkVariantsMetafieldFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
-        <paramters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
     </moqui.service.message.SystemMessageType>
 
     <!-- SystemMessageType record for sending bulk variants metafield query result to SFTP -->
@@ -157,7 +157,7 @@ under the License.
             sendPath="component://shopify-connector/template/graphQL/BulkOrderMetafieldsQuery.ftl"
             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
             receivePath="${contentRoot}/shopify/BulkOrderMetafieldsFeed/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
-        <paramters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
     </moqui.service.message.SystemMessageType>
 
     <!-- SystemMessageType record for sending bulk order metafields query result to SFTP -->
@@ -166,6 +166,50 @@ under the License.
             parentTypeId="LocalFeedFile"
             sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
             sendPath=""/>
+
+    <!-- SystemMessageType record for bulk order headers query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderHeadersQuery"
+            description="Bulk Order Headers Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderHeadersQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderHeadersQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order headers query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderHeadersQueryResult"
+            description="Send Bulk Order Headers Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderHeadersQuery and SendBulkOrderHeadersQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Headers Query Result" enumId="SendBulkOrderHeadersQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Headers Query" enumId="BulkOrderHeadersQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderHeadersQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+    <!-- SystemMessageType record for bulk order items query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderItemsQuery"
+            description="Bulk Order Items Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderItemsQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderItemsQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order items query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderItemsQueryResult"
+            description="Send Bulk Order Items Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderItemsQuery and SendBulkOrderItemsQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Items Query Result" enumId="SendBulkOrderItemsQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Items Query" enumId="BulkOrderItemsQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderItemsQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
 
     <!-- SystemMessageTypeRecord for deleting a specific webhook subscription -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="DeleteWebhookSubscription"

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade">
+
+    <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="BulkUpdateProductTags" parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="BulkUpdateProductVariants" parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="BulkVariantsMetafieldQuery" parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="BulkOrderMetafieldsQuery" parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+
+    <!-- SystemMessageType record for bulk order headers query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderHeadersQuery"
+            description="Bulk Order Headers Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderHeadersQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderHeadersQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order headers query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderHeadersQueryResult"
+            description="Send Bulk Order Headers Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderHeadersQuery and SendBulkOrderHeadersQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Headers Query Result" enumId="SendBulkOrderHeadersQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Headers Query" enumId="BulkOrderHeadersQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderHeadersQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+    <!-- SystemMessageType record for bulk order items query to Shopify -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="BulkOrderItemsQuery"
+            description="Bulk Order Items Query System Message"
+            parentTypeId="ShopifyBulkQuery"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#BulkQuerySystemMessage"
+            sendPath="component://shopify-connector/template/graphQL/BulkOrderItemsQuery.ftl"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.consume#BulkOperationResult"
+            receivePath="${contentRoot}/shopify/BulkOrderItemsQuery/BulkOperationResult-${systemMessageId}-${remoteMessageId}-${nowDate}.jsonl">
+        <parameters parameterName="consumeSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- SystemMessageType record for sending bulk order items query result to SFTP -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendBulkOrderItemsQueryResult"
+            description="Send Bulk Order Items Query Result"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Enumeration to create relation between BulkOrderItemsQuery and SendBulkOrderItemsQueryResult SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Bulk Order Items Query Result" enumId="SendBulkOrderItemsQueryResult" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Bulk Order Items Query" enumId="BulkOrderItemsQuery" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendBulkOrderItemsQueryResult" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+    <!-- ServiceJob data for queuing bulk order headers query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderHeadersQuery" description="Queue bulk order headers query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderHeadersQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+
+    <!-- ServiceJob data for queuing bulk updated order items query -->
+    <moqui.service.job.ServiceJob jobName="queue_BulkQuerySystemMessage_BulkOrderItemsQuery" description="Queue bulk order items query"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="BulkOrderItemsQuery"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="filterQuery" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="fromDateLabel" parameterValue=""/>
+        <parameters parameterName="thruDateLabel" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+</entity-facade-xml>

--- a/service/co/hotwax/impl/SystemMessageServices.xml
+++ b/service/co/hotwax/impl/SystemMessageServices.xml
@@ -25,11 +25,15 @@ under the License.
         </description>
         <in-parameters>
             <parameter name="purgeDays" type="Integer" default-value="30"/>
+            <parameter name="systemMessageTypeId"/>
+            <parameter name="parentSystemMessageTypeId"/>
         </in-parameters>
         <actions>
             <set field="purgeDate" from="java.sql.Timestamp.from(java.time.ZonedDateTime.now().minusDays(purgeDays.intValue()).toInstant())"/>
             <entity-find entity-name="moqui.service.message.SystemMessageAndType" list="systemMessages">
-                <econdition field-name="processedDate" operator="less" from="purgeDate"/>
+                <econdition field-name="initDate" operator="less" from="purgeDate"/>
+                <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId" ignore-if-empty="true"/>
+                <econdition field-name="parentTypeId" operator="equals" from="parentSystemMessageTypeId" ignore-if-empty="true"/>
                 <use-iterator/>
             </entity-find>
             <iterate list="systemMessages" entry="systemMessage">

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -36,10 +36,10 @@ under the License.
             <script>
                 queryString = new StringBuffer()
                 queryString.append("status=").append(status)
-                if (createdFromDate) queryString.append("&amp;&amp;created_at_min=").append(createdFromDate)
-                if (createdThruDate) queryString.append("&amp;&amp;created_at_max=").append(createdThruDate)
-                if (updatedFromDate) queryString.append("&amp;&amp;updated_at_min=").append(updatedFromDate)
-                if (updatedThruDate) queryString.append("&amp;&amp;updated_at_max=").append(updatedThruDate)
+                if (createdFromDate) queryString.append("&amp;&amp;created_at_min=").append(ZonedDateTime.ofInstant(Timestamp.valueOf(createdFromDate).toInstant(), ZoneId.of("UTC")).toString())
+                if (createdThruDate) queryString.append("&amp;&amp;created_at_max=").append(ZonedDateTime.ofInstant(Timestamp.valueOf(createdThruDate).toInstant(), ZoneId.of("UTC")).toString())
+                if (updatedFromDate) queryString.append("&amp;&amp;updated_at_min=").append(ZonedDateTime.ofInstant(Timestamp.valueOf(updatedFromDate).toInstant(), ZoneId.of("UTC")).toString())
+                if (updatedThruDate) queryString.append("&amp;&amp;updated_at_max=").append(ZonedDateTime.ofInstant(Timestamp.valueOf(updatedThruDate).toInstant(), ZoneId.of("UTC")).toString())
                 if (financialStatus) queryString.append("&amp;&amp;financial_status=").append(financialStatus)
                 if (fulfilmentStatus) queryString.append("&amp;&amp;fulfillment_status=").append(fulfilmentStatus)
             </script>

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://moqui.org/xsd/service-definition-3.xsd">
+    <service verb="get" noun="OrderCount" authenticate="anonymous-all">
+        <description>Get Shopify Order Count on given parameters</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="createdFromDate"/>
+            <parameter name="createdThruDate"/>
+            <parameter name="updatedFromDate"/>
+            <parameter name="updatedThruDate"/>
+            <parameter name="status" default-value="any"/>
+            <parameter name="financialStatus"/>
+            <parameter name="fulfilmentStatus"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="orderCount"/>
+        </out-parameters>
+        <actions>
+            <script>
+                queryString = new StringBuffer()
+                queryString.append("status=").append(status)
+                if (createdFromDate) queryString.append("&amp;&amp;created_at_min=").append(createdFromDate)
+                if (createdThruDate) queryString.append("&amp;&amp;created_at_max=").append(createdThruDate)
+                if (updatedFromDate) queryString.append("&amp;&amp;updated_at_min=").append(updatedFromDate)
+                if (updatedThruDate) queryString.append("&amp;&amp;updated_at_max=").append(updatedThruDate)
+                if (financialStatus) queryString.append("&amp;&amp;financial_status=").append(financialStatus)
+                if (fulfilmentStatus) queryString.append("&amp;&amp;fulfillment_status=").append(fulfilmentStatus)
+            </script>
+            <set field="endPoint" value="orders/count.json?${queryString}"/>
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, endPoint:endPoint,
+                        requestType:'GET', contentType:'application/json']" out-map="orderCountResponse"/>
+
+            <if condition="orderCountResponse.statusCode != 200">
+                <return error="true" message="System message from SystemMessageRemote with ID
+                    ${systemMessageRemoteId} sent error response ${orderCountResponse.statusCode}: ${orderCountResponse.response}"/>
+            </if>
+
+            <set field="orderCount" from="orderCountResponse.response.count"/>
+        </actions>
+    </service>
+</services>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -191,6 +191,9 @@ under the License.
                           out-map="bulkOperationResult"/>
 
             <set field="status" from="bulkOperationResult.response.status"/>
+            <if condition="'created'.equalsIgnoreCase(status) || 'running'.equalsIgnoreCase(status)">
+                <set field="responseText" value="The bulk operation for systemMessageId:[${systemMessageId}] with systemMessageType:[${systemMessage.systemMessageTypeId}] not yet completed at Shopify."/>
+            </if>
             <set field="nowDate" from="ec.user.nowTimestamp"/>
             <if condition="'failed'.equalsIgnoreCase(status)">
                 <service-call name="create#moqui.service.message.SystemMessageError" in-map="[systemMessageId:systemMessageId, errorDate:nowDate, errorText:bulkOperationResult.response.errorCode]"/>
@@ -283,9 +286,11 @@ under the License.
             <parameter name="filterQuery"/>
             <parameter name="fromDate"/>
             <parameter name="thruDate"/>
+            <parameter name="fromDateLabel"/>
+            <parameter name="thruDateLabel"/>
         </in-parameters>
         <actions>
-            <set field="paramMap" from="[filterQuery:filterQuery, fromDate:fromDate, thruDate:thruDate]"/>
+            <set field="paramMap" from="[filterQuery:filterQuery, fromDate:fromDate, thruDate:thruDate, fromDateLabel:fromDateLabel, thruDateLabel:thruDateLabel]"/>
             <set field="messageText" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(paramMap)"/>
             <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                           in-map="[systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, messageText:messageText, consumeSmrId:consumeSmrId, sendNow:false]"
@@ -347,6 +352,12 @@ under the License.
                     <set field="thruZdtUTC" from="thruZdtUTC.minusMinutes(Integer.valueOf(queryParams.thruDateBuffer))"/>
                 </if>
                 <set field="queryParams.thruDate" from="thruZdtUTC.toString()"/>
+            </if>
+            <if condition="systemMessageParams.fromDateLabel">
+                <set field="queryParams.fromDateLabel" from="systemMessageParams.fromDateLabel"/>
+            </if>
+            <if condition="systemMessageParams.thruDateLabel">
+                <set field="queryParams.thruDateLabel" from="systemMessageParams.thruDateLabel"/>
             </if>
             <set field="requestBody.queryParams" from="queryParams"/>
 

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -191,6 +191,9 @@ under the License.
                           out-map="bulkOperationResult"/>
 
             <set field="status" from="bulkOperationResult.response.status"/>
+            <if condition="!status">
+                <set field="status" value="failed"/>
+            </if>
             <if condition="'created'.equalsIgnoreCase(status) || 'running'.equalsIgnoreCase(status)">
                 <set field="responseText" value="The bulk operation for systemMessageId:[${systemMessageId}] with systemMessageType:[${systemMessage.systemMessageTypeId}] not yet completed at Shopify."/>
             </if>

--- a/service/shopify.rest.xml
+++ b/service/shopify.rest.xml
@@ -24,4 +24,18 @@ under the License.
             <method type="post"><service name="co.hotwax.shopify.webhook.ShopifyWebhookServices.receive#WebhookPayload"/></method>
         </resource>
     </resource>
+    <resource name="order" require-authentication="anonymous-all">
+        <resource name="count" require-authentication="anonymous-all">
+            <method type="get">
+                <service name="co.hotwax.shopify.order.ShopifyOrderServices.get#OrderCount"/>
+            </method>
+        </resource>
+    </resource>
+    <resource name="bulk" require-authentication="anonymous-all">
+        <resource name="query" require-authentication="anonymous-all">
+            <method type="post">
+                <service name="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#BulkQuerySystemMessage"/>
+            </method>
+        </resource>
+    </resource>
 </resource>

--- a/template/graphQL/BulkOrderHeadersQuery.ftl
+++ b/template/graphQL/BulkOrderHeadersQuery.ftl
@@ -1,0 +1,93 @@
+<#--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<@compress single_line=true>
+    <#if queryParams?has_content>
+        <#if queryParams.filterQuery?has_content>
+            <#assign filterQuery = queryParams.filterQuery/>
+        <#else>
+            <#if queryParams.fromDateLabel?has_content>
+                <#assign fromDateLabel = queryParams.fromDateLabel/>
+            <#else>
+                <#assign fromDateLabel = "created_at"/>
+            </#if>
+            <#if queryParams.thruDateLabel?has_content>
+                <#assign thruDateLabel = queryParams.thruDateLabel/>
+            <#else>
+                <#assign thruDateLabel = "created_at"/>
+            </#if>
+            <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}'"/>
+            </#if>
+            <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                <#assign filterQuery = "${thruDateLabel}:<'${queryParams.thruDate}'"/>
+            </#if>
+            <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}' AND ${thruDateLabel}:<'${queryParams.thruDate}'"/>
+            </#if>
+        </#if>
+    </#if>
+
+    mutation {
+        bulkOperationRunQuery(
+            query: """ {
+                orders <#if filterQuery?has_content>(query:"${filterQuery}")</#if> {
+                    edges {
+                        node {
+                            id
+                            name
+                            confirmed
+                            createdAt
+                            updatedAt
+                            processedAt
+                            cancelledAt
+                            closed
+                            closedAt
+                            subtotalLineItemsQuantity
+                            totalPriceSet{
+                                presentmentMoney{
+                                    amount
+                                    currencyCode
+                                }
+                                shopMoney{
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                            currencyCode
+                            fulfillments {
+                                id
+                            }
+                            refunds {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        """ ) {
+            bulkOperation {
+                id
+                status
+            }
+            userErrors {
+                field
+                message
+            }
+        }
+    }
+</@compress>

--- a/template/graphQL/BulkOrderItemsQuery.ftl
+++ b/template/graphQL/BulkOrderItemsQuery.ftl
@@ -1,0 +1,111 @@
+<#--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<@compress single_line=true>
+    <#if queryParams?has_content>
+        <#if queryParams.filterQuery?has_content>
+            <#assign filterQuery = queryParams.filterQuery/>
+        <#else>
+            <#if queryParams.fromDateLabel?has_content>
+              <#assign fromDateLabel = queryParams.fromDateLabel/>
+            <#else>
+              <#assign fromDateLabel = "created_at"/>
+            </#if>
+            <#if queryParams.thruDateLabel?has_content>
+                <#assign thruDateLabel = queryParams.thruDateLabel/>
+            <#else>
+                <#assign thruDateLabel = "created_at"/>
+            </#if>
+            <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}'"/>
+            </#if>
+            <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                <#assign filterQuery = "${thruDateLabel}:<'${queryParams.thruDate}'"/>
+            </#if>
+            <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}' AND ${thruDateLabel}:<'${queryParams.thruDate}'"/>
+            </#if>
+        </#if>
+    </#if>
+    mutation {
+        bulkOperationRunQuery(
+            query: """ {
+                orders<#if filterQuery?has_content>(query:"${filterQuery}")</#if> {
+                    edges {
+                        node {
+                            id
+                            name
+                            confirmed
+                            createdAt
+                            updatedAt
+                            processedAt
+                            cancelledAt
+                            closed
+                            closedAt
+                            subtotalLineItemsQuantity
+                            totalPriceSet {
+                                presentmentMoney {
+                                    amount
+                                    currencyCode
+                                }
+                                shopMoney {
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                            currencyCode
+                            fulfillments {
+                                id
+                                status
+                            }
+                            refunds {
+                                id
+                            }
+                            lineItems {
+                                edges {
+                                    node {
+                                        id
+                                        title
+                                        quantity
+                                        currentQuantity
+                                        nonFulfillableQuantity
+                                        refundableQuantity
+                                        product {
+                                            id
+                                            isGiftCard
+                                            productType
+                                            tracksInventory
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        """ ) {
+            bulkOperation {
+                id
+                status
+            }
+            userErrors {
+                field
+                message
+            }
+        }
+    }
+</@compress>

--- a/template/graphQL/BulkOrderMetafieldsQuery.ftl
+++ b/template/graphQL/BulkOrderMetafieldsQuery.ftl
@@ -20,14 +20,24 @@ under the License.
       <#if queryParams.filterQuery?has_content>
         <#assign filterQuery = queryParams.filterQuery/>
       <#else>
+          <#if queryParams.fromDateLabel?has_content>
+              <#assign fromDateLabel = queryParams.fromDateLabel/>
+          <#else>
+              <#assign fromDateLabel = "created_at"/>
+          </#if>
+          <#if queryParams.thruDateLabel?has_content>
+              <#assign thruDateLabel = queryParams.thruDateLabel/>
+          <#else>
+              <#assign thruDateLabel = "created_at"/>
+          </#if>
           <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
-              <#assign filterQuery = "created_at:>'${queryParams.fromDate}'"/>
+              <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}'"/>
           </#if>
           <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
-              <#assign filterQuery = "created_at:<'${queryParams.thruDate}'"/>
+              <#assign filterQuery = "${thruDateLabel}:<'${queryParams.thruDate}'"/>
           </#if>
           <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
-              <#assign filterQuery = "created_at:>'${queryParams.fromDate}' AND created_at:<'${queryParams.thruDate}'"/>
+              <#assign filterQuery = "${fromDateLabel}:>'${queryParams.fromDate}' AND ${thruDateLabel}:<'${queryParams.thruDate}'"/>
           </#if>
       </#if>
     </#if>


### PR DESCRIPTION
1. Includes following enhancements and improvements, (https://github.com/hotwax/mantle-shopify-connector/commit/17778fceacc3cd5dee52428bcd8b46b6b7acf1e4)
    - Implemented api integration service to get shopify order count and added rest end point for it.
    - Added rest end point for shopify bulk query operation.
    - Added support for fromDateLabel and thruDateLabel in shopify bulk query operation.
    - Added support for bulk order headers query and bulk order items query.
    - Handled "create" and "running" bulk operation result statuses.
2. Added support to purge system messages by systemMessageTypeId or parentSystemMessageTypeId. Used initDate for purgeDate comparison as processedDate may be empty. (https://github.com/hotwax/mantle-shopify-connector/commit/8210d8102ce22b52025c9ade6b1ef76f9afc7244)
3. Handled NULL bulk operation status. (https://github.com/hotwax/mantle-shopify-connector/commit/d95c7c3f602ed2a17c95e8ba3fb009f95a64fe61)