### PR TITLE
Added: get#OrderDetails Shopify graqhQL API integration service to return order header and line item details for a given Shopify orderId.

### DIFF
--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -6,8 +6,7 @@
     <moqui.resource.DbResource filename="graphQL" isFile="N" resourceId="GraphQL" parentResourceId="Template"/>
     <moqui.resource.DbResource filename="OrderHeaderByIdQuery.ftl" isFile="Y" resourceId="OrderHeaderByIdQuery" parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData><![CDATA[
-<#ftl output_format="HTML">
+            <fileData><![CDATA[<#ftl output_format="HTML">
 <@compress single_line=true>
 query{
     node(id: "${shopifyOrderId}") {
@@ -57,14 +56,12 @@ query{
         }
     }
 }
-</@compress>
-]]></fileData>
+</@compress>]]></fileData>
         </file>
     </moqui.resource.DbResource>
     <moqui.resource.DbResource filename="OrderLineItemByIdQuery.ftl" isFile="Y" resourceId="OrderLineItemByIdQuery" parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData><![CDATA[
-<#ftl output_format="HTML">
+            <fileData><![CDATA[<#ftl output_format="HTML">
 <@compress single_line=true>
 query {
     node(id: "${shopifyOrderId}") {
@@ -93,8 +90,7 @@ query {
         }
     }
 }
-</@compress>
-]]></fileData>
+</@compress>]]></fileData>
         </file>
     </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -4,93 +4,99 @@
     <moqui.resource.DbResource filename="shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
     <moqui.resource.DbResource filename="template" isFile="N" resourceId="Template" parentResourceId="Shopify"/>
     <moqui.resource.DbResource filename="graphQL" isFile="N" resourceId="GraphQL" parentResourceId="Template"/>
-    <moqui.resource.DbResource filename="OrderHeaderByIdQuery.ftl" isFile="Y" resourceId="OrderHeaderByIdQuery" parentResourceId="GraphQL">
+    <moqui.resource.DbResource filename="OrderHeaderByIdQuery.ftl" isFile="Y" resourceId="OrderHeaderByIdQuery"
+                               parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData><![CDATA[<#ftl output_format="HTML">
-<@compress single_line=true>
-query{
-    node(id: "${shopifyOrderId}") {
-        id
-        ... on
-        Order {
-            id
-            name
-            updatedAt
-            returnStatus
-            customer {
-                    id
-                    firstName
-                    lastName
-                    email
-                    phone
-                }
-            originalTotalPriceSet {
-                presentmentMoney {
-                    amount
-                    currencyCode
-                }
-            }
-            currentTotalPriceSet {
-                presentmentMoney {
-                    amount
-                    currencyCode
-                }
-            }
-            channelInformation {
-                channelId
-                channelDefinition {
-                    channelName
-                }
-            }
-            billingAddress {
-                firstName
-                lastName
-                address1
-                address2
-                city
-                provinceCode
-                countryCodeV2
-                phone
-                zip
-            }
-        }
-    }
-}
-</@compress>]]></fileData>
-        </file>
-    </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="OrderLineItemByIdQuery.ftl" isFile="Y" resourceId="OrderLineItemByIdQuery" parentResourceId="GraphQL">
-        <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData><![CDATA[<#ftl output_format="HTML">
-<@compress single_line=true>
-query {
-    node(id: "${shopifyOrderId}") {
-        id
-        ... on
-        Order {
-            id
-            name
-            lineItems (first: 3<#if cursor?has_content>, after: "${cursor}"</#if>) {
-                edges {
-                    node {
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${shopifyOrderId}") {
                         id
-                        variant {
+                        ... on
+                        Order {
                             id
-                            barcode
-                            sku
+                            name
+                            updatedAt
+                            returnStatus
+                            customer {
+                                id
+                                firstName
+                                lastName
+                                email
+                                phone
+                            }
+                            originalTotalPriceSet {
+                                presentmentMoney {
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                            currentTotalPriceSet {
+                                presentmentMoney {
+                                    amount
+                                    currencyCode
+                                }
+                            }
+                            channelInformation {
+                                channelId
+                                channelDefinition {
+                                    channelName
+                                }
+                            }
+                            billingAddress {
+                                firstName
+                                lastName
+                                address1
+                                address2
+                                city
+                                provinceCode
+                                countryCodeV2
+                                phone
+                                zip
+                            }
                         }
-                        quantity
                     }
                 }
-                pageInfo {
-                    endCursor
-                    hasNextPage
+                </@compress>]]>
+            </fileData>
+        </file>
+    </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="OrderLineItemByIdQuery.ftl" isFile="Y" resourceId="OrderLineItemByIdQuery"
+                               parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query {
+                    node(id: "${shopifyOrderId}") {
+                        id
+                        ... on
+                        Order {
+                            id
+                            name
+                            lineItems (first: 3<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                        variant {
+                                            id
+                                            barcode
+                                            sku
+                                        }
+                                        quantity
+                                    }
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}
-</@compress>]]></fileData>
+                </@compress>]]>
+            </fileData>
         </file>
     </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed">
+    <!--    DbResource of Shopify GraphQL Templates-->
+    <moqui.resource.DbResource filename="Shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
+    <moqui.resource.DbResource filename="template" isFile="N" resourceId="template" parentResourceId="Shopify"/>
+    <moqui.resource.DbResource filename="GraphQL" isFile="N" resourceId="GraphQL" parentResourceId="template"/>
+    <moqui.resource.DbResource filename="OrderHeaderByIdQuery.ftl" isFile="Y" resourceId="OrderHeaderByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData><![CDATA[
+<#ftl output_format="HTML">
+<@compress single_line=true>
+query{
+    node(id: "${shopifyOrderId}") {
+        id
+        ... on
+        Order {
+            id
+            name
+            updatedAt
+            returnStatus
+            customer {
+                    id
+                    firstName
+                    lastName
+                    email
+                    phone
+                }
+            originalTotalPriceSet {
+                presentmentMoney {
+                    amount
+                    currencyCode
+                }
+            }
+            currentTotalPriceSet {
+                presentmentMoney {
+                    amount
+                    currencyCode
+                }
+            }
+            channelInformation {
+                channelId
+                channelDefinition {
+                    channelName
+                }
+            }
+            billingAddress {
+                firstName
+                lastName
+                address1
+                address2
+                city
+                provinceCode
+                countryCodeV2
+                phone
+                zip
+            }
+        }
+    }
+}
+</@compress>
+]]></fileData>
+        </file>
+    </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="OrderLineItemByIdQuery.ftl" isFile="Y" resourceId="OrderLineItemByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData><![CDATA[
+<#ftl output_format="HTML">
+<@compress single_line=true>
+query {
+    node(id: "${shopifyOrderId}") {
+        id
+        ... on
+        Order {
+            id
+            name
+            lineItems (first: 3<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                edges {
+                    node {
+                        id
+                        variant {
+                            id
+                            barcode
+                            sku
+                        }
+                        quantity
+                    }
+                    cursor
+                }
+                pageInfo {
+                    endCursor
+                    hasNextPage
+                }
+            }
+        }
+    }
+}
+</@compress>
+]]></fileData>
+        </file>
+    </moqui.resource.DbResource>
+</entity-facade-xml>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -84,7 +84,6 @@ query {
                         }
                         quantity
                     }
-                    cursor
                 }
                 pageInfo {
                     endCursor

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity-facade-xml type="seed">
     <!--    DbResource of Shopify GraphQL Templates-->
-    <moqui.resource.DbResource filename="Shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
-    <moqui.resource.DbResource filename="template" isFile="N" resourceId="template" parentResourceId="Shopify"/>
-    <moqui.resource.DbResource filename="GraphQL" isFile="N" resourceId="GraphQL" parentResourceId="template"/>
+    <moqui.resource.DbResource filename="shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
+    <moqui.resource.DbResource filename="template" isFile="N" resourceId="Template" parentResourceId="Shopify"/>
+    <moqui.resource.DbResource filename="graphQL" isFile="N" resourceId="GraphQL" parentResourceId="Template"/>
     <moqui.resource.DbResource filename="OrderHeaderByIdQuery.ftl" isFile="Y" resourceId="OrderHeaderByIdQuery" parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData><![CDATA[

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -107,7 +107,7 @@ under the License.
     <service verb="get" noun="OrderDetails">
         <description>Get order details for a given shopify orderId</description>
         <in-parameters>
-            <parameter name="systemMessageRemoteId"/>
+            <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="shopifyOrderId" required="true"/>
         </in-parameters>
         <out-parameters>

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -148,13 +148,13 @@ under the License.
                     <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>
                 </if>
                 <if condition="orderLineItemResponse.response.node.lineItems.edges">
-                    <script>orderLineItems.addAll(orderLineItemResponse.response.node.lineItems.edges)</script>
+                    <script>orderLineItems.addAll(orderLineItemResponse.response.node.lineItems.edges.node)</script>
                 </if>
                 <set field="hasNextPage" from="orderLineItemResponse.response.node.lineItems.pageInfo.hasNextPage"/>
                 <set field="cursor" from="orderLineItemResponse.response.node.lineItems.pageInfo.endCursor"/>
             </while>
-            <set field="orderDetail" from="orderHeaderResponse.response"/>
-            <script>orderDetail.node.lineItems = orderLineItems</script>
+            <set field="orderDetail" from="orderHeaderResponse.response.node"/>
+            <set field="orderDetail.lineItems" from="orderLineItems"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -104,4 +104,57 @@ under the License.
             </while>
         </actions>
     </service>
+    <service verb="get" noun="OrderDetails">
+        <description>Get order details for a given shopify orderId</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId"/>
+            <parameter name="shopifyOrderId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="orderDetail"/>
+        </out-parameters>
+        <actions>
+            <script>
+                StringWriter sw = new StringWriter()
+                ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/GraphQL/OrderHeaderByIdQuery.ftl", sw)
+                queryText = sw.toString()
+                ec.logger.info ("queryText" + queryText)
+                try {
+                    sw.close()
+                } catch (IOException e) {
+                    ec.logger.error("Error closing StringWriter")
+                }
+            </script>
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="orderHeaderResponse"/>
+            <if condition="!orderHeaderResponse.response.node">
+                <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>
+            </if>
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <set field="orderLineItems" from="[]"/>
+            <while condition="hasNextPage">
+                <script>
+                    StringWriter sw1 = new StringWriter()
+                    ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/graphQL/OrderLineItemByIdQuery.ftl", sw1)
+                    queryText = sw1.toString()
+                    ec.logger.info ("queryText" + queryText)
+                    try {
+                        sw1.close()
+                    } catch (IOException e) {
+                        ec.logger.error("Error closing StringWriter")
+                    }
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="orderLineItemResponse"/>
+                <if condition="!orderLineItemResponse.response.node">
+                    <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>
+                </if>
+                <if condition="orderLineItemResponse.response.node.lineItems.edges">
+                    <script>orderLineItems.addAll(orderLineItemResponse.response.node.lineItems.edges)</script>
+                </if>
+                <set field="hasNextPage" from="orderLineItemResponse.response.node.lineItems.pageInfo.hasNextPage"/>
+                <set field="cursor" from="orderLineItemResponse.response.node.lineItems.pageInfo.endCursor"/>
+            </while>
+            <set field="orderDetail" from="orderHeaderResponse.response"/>
+            <script>orderDetail.node.lineItems = orderLineItems</script>
+        </actions>
+    </service>
 </services>

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -144,9 +144,6 @@ under the License.
                     }
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="orderLineItemResponse"/>
-                <if condition="!orderLineItemResponse.response.node">
-                    <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>
-                </if>
                 <if condition="orderLineItemResponse.response.node.lineItems.edges">
                     <script>orderLineItems.addAll(orderLineItemResponse.response.node.lineItems.edges.node)</script>
                 </if>

--- a/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
+++ b/service/co/hotwax/shopify/order/ShopifyOrderServices.xml
@@ -116,7 +116,7 @@ under the License.
         <actions>
             <script>
                 StringWriter sw = new StringWriter()
-                ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/GraphQL/OrderHeaderByIdQuery.ftl", sw)
+                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/OrderHeaderByIdQuery.ftl", sw)
                 queryText = sw.toString()
                 ec.logger.info ("queryText" + queryText)
                 try {
@@ -134,7 +134,7 @@ under the License.
             <while condition="hasNextPage">
                 <script>
                     StringWriter sw1 = new StringWriter()
-                    ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/graphQL/OrderLineItemByIdQuery.ftl", sw1)
+                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/OrderLineItemByIdQuery.ftl", sw1)
                     queryText = sw1.toString()
                     ec.logger.info ("queryText" + queryText)
                     try {


### PR DESCRIPTION
**Service**: get#OrderDetails

* It gets order details for a given Shopify orderId

**GraphQL Query Templates**:
1. OrderHeaderByIdQuery template for order header level details.
2. OrderLineItemByIdQuery template for fetching line item details