### PR TITLE
Added: get#FulfillmentOrderDetails and get#FulfillmentOrdersByOrderId Shopify graqhQL API integration services to get fulfillment details for a given Shopify fulfillmentOrderId and orderId.

### DIFF
--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -99,7 +99,48 @@
             </fileData>
         </file>
     </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="FulfillmentByIdQuery.ftl" isFile="Y" resourceId="FulfillmentByIdQuery" parentResourceId="GraphQL">
+    <moqui.resource.DbResource filename="FulfillmentByOrderIdQuery.ftl" isFile="Y" resourceId="FulfillmentByIdQuery"
+                               parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${shopifyOrderId}") {
+                        id
+                        ... on
+                        Order {
+                            id
+                            name
+                            fulfillmentOrders (first: 5<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                        status
+                                        updatedAt
+                                        fulfillAt
+                                        channelId
+                                        assignedLocation {
+                                            location {
+                                                id
+                                            }
+                                        }
+                                    }
+                                }
+                                pageInfo{
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    }
+                }
+                </@compress>]]>
+            </fileData>
+        </file>
+    </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="FulfillmentLineItemsByIdQuery.ftl" isFile="Y"
+                               resourceId="FulfillmentLineItemsByIdQuery" parentResourceId="GraphQl">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
                 <![CDATA[<#ftl output_format="HTML">
@@ -111,20 +152,18 @@
                         FulfillmentOrder {
                             id
                             status
-                            updatedAt
-                            fulfillAt
-                            channelId
-                            assignedLocation {
-                                location {
-                                    id
+                            lineItems (first : 5<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                edges{
+                                    node {
+                                        id
+                                        sku
+                                        variantTitle
+                                        productTitle
+                                    }
                                 }
-                            }
-                            lineItems (first : 5) {
-                                nodes {
-                                    id
-                                    sku
-                                    variantTitle
-                                    productTitle
+                                pageInfo{
+                                    endCursor
+                                    hasNextPage
                                 }
                             }
                         }

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -116,15 +116,6 @@
                                 edges {
                                     node {
                                         id
-                                        status
-                                        updatedAt
-                                        fulfillAt
-                                        channelId
-                                        assignedLocation {
-                                            location {
-                                                id
-                                            }
-                                        }
                                     }
                                 }
                                 pageInfo{
@@ -139,7 +130,35 @@
             </fileData>
         </file>
     </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="FulfillmentLineItemsByIdQuery.ftl" isFile="Y"
+    <moqui.resource.DbResource filename="FulfillmentHeaderByIdQuery.ftl" isFile="Y"
+                               resourceId="FulfillmentHeaderByIdQuery" parentResourceId="GraphQl">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${fulfillmentOrderId}") {
+                        id
+                        ... on
+                        FulfillmentOrder {
+                            id
+                            status
+                            updatedAt
+                            fulfillAt
+                            channelId
+                            assignedLocation {
+                                location {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+                </@compress>]]>
+            </fileData>
+        </file>
+    </moqui.resource.DbResource>
+<moqui.resource.DbResource filename="FulfillmentLineItemsByIdQuery.ftl" isFile="Y"
                                resourceId="FulfillmentLineItemsByIdQuery" parentResourceId="GraphQl">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -99,7 +99,7 @@
             </fileData>
         </file>
     </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="FulfillmentByOrderIdQuery.ftl" isFile="Y" resourceId="FulfillmentByIdQuery"
+    <moqui.resource.DbResource filename="FulfillmentOrdersByOrderIdQuery.ftl" isFile="Y" resourceId="FulfillmentOrdersByOrderIdQuery"
                                parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
@@ -130,8 +130,8 @@
             </fileData>
         </file>
     </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="FulfillmentHeaderByIdQuery.ftl" isFile="Y"
-                               resourceId="FulfillmentHeaderByIdQuery" parentResourceId="GraphQl">
+    <moqui.resource.DbResource filename="FulfillmentOrderHeaderByIdQuery.ftl" isFile="Y"
+                               resourceId="FulfillmentOrderHeaderByIdQuery" parentResourceId="GraphQl">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
                 <![CDATA[<#ftl output_format="HTML">
@@ -158,8 +158,8 @@
             </fileData>
         </file>
     </moqui.resource.DbResource>
-<moqui.resource.DbResource filename="FulfillmentLineItemsByIdQuery.ftl" isFile="Y"
-                               resourceId="FulfillmentLineItemsByIdQuery" parentResourceId="GraphQl">
+<moqui.resource.DbResource filename="FulfillmentOrderLineItemsByIdQuery.ftl" isFile="Y"
+                               resourceId="FulfillmentOrderLineItemsByIdQuery" parentResourceId="GraphQl">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
                 <![CDATA[<#ftl output_format="HTML">
@@ -170,7 +170,6 @@
                         ... on
                         FulfillmentOrder {
                             id
-                            status
                             lineItems (first : 5<#if cursor?has_content>, after: "${cursor}"</#if>) {
                                 edges{
                                     node {

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <entity-facade-xml type="seed">
     <!--    DbResource of Shopify GraphQL Templates-->
-    <moqui.resource.DbResource filename="Shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
-    <moqui.resource.DbResource filename="template" isFile="N" resourceId="template" parentResourceId="Shopify"/>
-    <moqui.resource.DbResource filename="GraphQL" isFile="N" resourceId="GraphQL" parentResourceId="template"/>
+    <moqui.resource.DbResource filename="shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
+    <moqui.resource.DbResource filename="template" isFile="N" resourceId="Template" parentResourceId="Shopify"/>
+    <moqui.resource.DbResource filename="graphQL" isFile="N" resourceId="GraphQL" parentResourceId="Template"/>
     <moqui.resource.DbResource filename="FulfillmentByIdQuery.ftl" isFile="Y" resourceId="FulfillmentByIdQuery" parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData><![CDATA[
-<#ftl output_format="HTML">
-<@compress single_line=true>
-query{
-    node(id: "${fulfillmentOrderId}") {
-        id
-        ... on
-        FulfillmentOrder {
-            id
-            status
-            updatedAt
-            fulfillAt
-            channelId
-            assignedLocation {
-                location {
-                    id
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${fulfillmentOrderId}") {
+                        id
+                        ... on
+                        FulfillmentOrder {
+                            id
+                            status
+                            updatedAt
+                            fulfillAt
+                            channelId
+                            assignedLocation {
+                                location {
+                                    id
+                                }
+                            }
+                            lineItems (first : 5) {
+                                nodes {
+                                    id
+                                    sku
+                                    variantTitle
+                                    productTitle
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            lineItems (first : 5) {
-                nodes {
-                    id
-                    sku
-                    variantTitle
-                    productTitle
-                }
-            }
-        }
-    }
-}
-</@compress>
-]]></fileData>
+                </@compress>]]>
+            </fileData>
         </file>
     </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="seed">
+    <!--    DbResource of Shopify GraphQL Templates-->
+    <moqui.resource.DbResource filename="Shopify" isFile="N" resourceId="Shopify" parentResourceId=""/>
+    <moqui.resource.DbResource filename="template" isFile="N" resourceId="template" parentResourceId="Shopify"/>
+    <moqui.resource.DbResource filename="GraphQL" isFile="N" resourceId="GraphQL" parentResourceId="template"/>
+    <moqui.resource.DbResource filename="FulfillmentByIdQuery.ftl" isFile="Y" resourceId="FulfillmentByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData><![CDATA[
+<#ftl output_format="HTML">
+<@compress single_line=true>
+query{
+    node(id: "${fulfillmentOrderId}") {
+        id
+        ... on
+        FulfillmentOrder {
+            id
+            status
+            updatedAt
+            fulfillAt
+            channelId
+            assignedLocation {
+                location {
+                    id
+                }
+            }
+            lineItems (first : 5) {
+                nodes {
+                    id
+                    sku
+                    variantTitle
+                    productTitle
+                }
+            }
+        }
+    }
+}
+</@compress>
+]]></fileData>
+        </file>
+    </moqui.resource.DbResource>
+</entity-facade-xml>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -216,32 +216,102 @@ under the License.
                 remote ${systemMessageRemoteId}, saved response in messages ${shopifyFulfillmentAckOut.systemMessageId}"/>
         </actions>
     </service>
-    <service verb="get" noun="FulfillmentOrderDetails">
-        <description>Get fulfillment order details for a given fulfillmentOrder Id</description>
+    <service verb="get" noun="FulfillmentDetails">
+        <description>Get fulfillment details for the given fulfillmentOrderId</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="fulfillmentOrderId" required="true"/>
         </in-parameters>
         <out-parameters>
-            <parameter name="fulfillmentOrderDetail"/>
+            <parameter name="fulfillmentDetail"/>
         </out-parameters>
         <actions>
+            <set field="fulfillmentDetail" from="[:]"/>
             <script>
                 StringWriter sw = new StringWriter()
-                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentByIdQuery.ftl", sw)
+                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentHeaderByIdQuery.ftl", sw)
                 queryText = sw.toString()
-                ec.logger.info ("=====queryText" + queryText)
+                ec.logger.info ("queryText" + queryText)
                 try {
                     sw.close()
                 } catch (IOException e) {
                     ec.logger.error("Error closing StringWriter")
                 }
             </script>
-            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderResponse"/>
-            <if condition="!fulfillmentOrderResponse.response.node">
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentResponse"/>
+            <if condition="!fulfillmentResponse.response.node">
                 <return type="warning" message="No Shopify order found for id: ${fulfillmentOrderId}"/>
             </if>
-            <set field="fulfillmentOrderDetail" from="fulfillmentOrderResponse.response.node"/>
+            <set field="fulfillmentDetail" from="fulfillmentResponse.response.node"/>
+<!--            Getting Fulfillment LineItems details-->
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <set field="fulfillmentLineItems" from="[]"/>
+            <while condition="hasNextPage">
+                <script>
+                    StringWriter sw1 = new StringWriter()
+                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentLineItemsByIdQuery.ftl", sw1)
+                    queryText = sw1.toString()
+                    ec.logger.info ("queryText" + queryText)
+                    try {
+                        sw1.close()
+                    } catch (IOException e) {
+                        ec.logger.error("Error closing StringWriter")
+                    }
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentLineItemResponse"/>
+                <if condition="fulfillmentLineItemResponse.response.node.lineItems.edges">
+                    <script>fulfillmentLineItems.addAll(fulfillmentLineItemResponse.response.node.lineItems.edges.node)</script>
+                </if>
+                <set field="hasNextPage" from="fulfillmentLineItemResponse.response.node.lineItems.pageInfo.hasNextPage"/>
+                <set field="cursor" from="fulfillmentLineItemResponse.response.node.lineItems.pageInfo.endCursor"/>
+            </while>
+            <set field="fulfillmentDetail.lineItems" from="fulfillmentLineItems"/>
+        </actions>
+    </service>
+    <service verb="get" noun="FulfillmentByOrderDetails">
+        <description>Get fulfillment order details for a given fulfillmentOrder Id</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="shopifyOrderId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="fulfillmentByOrderDetail"/>
+        </out-parameters>
+        <actions>
+            <set field="fulfillmentByOrderDetail" from="[:]"/>
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <set field="fulfillmentOrders" from="[]"/>
+            <while condition="hasNextPage">
+                <script>
+                    StringWriter sw = new StringWriter()
+                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentByOrderIdQuery.ftl", sw)
+                    queryText = sw.toString()
+                    ec.logger.info ("queryText" + queryText)
+                    try {
+                        sw.close()
+                    } catch (IOException e) {
+                        ec.logger.error("Error closing StringWriter")
+                    }
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderResponse"/>
+                <if condition="!fulfillmentOrderResponse.response.node">
+                    <return type="warning" message="No fulfillment order found for id: ${fulfillmentOrderId}"/>
+                </if>
+                <if condition="fulfillmentOrderResponse.response.node.fulfillmentOrders.edges">
+                    <script>fulfillmentOrders.addAll(fulfillmentOrderResponse.response.node.fulfillmentOrders.edges.node)</script>
+                </if>
+                <set field="fulfillmentOrderDetailsList" from="[]"/>
+                <set field="fulfillmentOrderIdList" from="fulfillmentOrders.id"/>
+                <iterate list="fulfillmentOrderIdList" entry="fulfillmentOrderId">
+                    <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, fulfillmentOrderId:fulfillmentOrderId]" out-map="fulfillmentDetail"/>
+                    <script>fulfillmentOrderDetailsList.addAll(fulfillmentDetail.fulfillmentDetail)</script>
+                </iterate>
+                <set field="hasNextPage" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.hasNextPage"/>
+                <set field="cursor" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.endCursor"/>
+            </while>
+            <set field="fulfillmentByOrderDetail.id" from="fulfillmentOrderResponse.response.node.id"/>
+            <set field="fulfillmentByOrderDetail.name" from="fulfillmentOrderResponse.response.node.name"/>
+            <set field="fulfillmentByOrderDetail.fulfillmentOrders" from="fulfillmentOrderDetailsList"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -229,7 +229,7 @@ under the License.
             <set field="fulfillmentDetail" from="[:]"/>
             <script>
                 StringWriter sw = new StringWriter()
-                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentHeaderByIdQuery.ftl", sw)
+                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentOrderHeaderByIdQuery.ftl", sw)
                 queryText = sw.toString()
                 ec.logger.info ("queryText" + queryText)
                 try {
@@ -249,7 +249,7 @@ under the License.
             <while condition="hasNextPage">
                 <script>
                     StringWriter sw1 = new StringWriter()
-                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentLineItemsByIdQuery.ftl", sw1)
+                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentOrderLineItemsByIdQuery.ftl", sw1)
                     queryText = sw1.toString()
                     ec.logger.info ("queryText" + queryText)
                     try {
@@ -268,23 +268,23 @@ under the License.
             <set field="fulfillmentDetail.lineItems" from="fulfillmentLineItems"/>
         </actions>
     </service>
-    <service verb="get" noun="FulfillmentByOrderDetails">
+    <service verb="get" noun="FulfillmentOrdersByOrderId">
         <description>Get all fulfillment order details for a given shopify order Id</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="shopifyOrderId" required="true"/>
         </in-parameters>
         <out-parameters>
-            <parameter name="fulfillmentByOrderDetail"/>
+            <parameter name="fulfillmentOrdersByOrderId"/>
         </out-parameters>
         <actions>
-            <set field="fulfillmentByOrderDetail" from="[:]"/>
+            <set field="fulfillmentOrdersByOrderId" from="[:]"/>
             <set field="hasNextPage" type="Boolean" value="true"/>
             <set field="fulfillmentOrders" from="[]"/>
             <while condition="hasNextPage">
                 <script>
                     StringWriter sw = new StringWriter()
-                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentByOrderIdQuery.ftl", sw)
+                    ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentOrdersByOrderIdQuery.ftl", sw)
                     queryText = sw.toString()
                     ec.logger.info ("queryText" + queryText)
                     try {
@@ -297,21 +297,22 @@ under the License.
                 <if condition="!fulfillmentOrderResponse.response.node">
                     <return type="warning" message="No shopify order found for id: ${shopifyOrderId}"/>
                 </if>
+<!--                Getting all the fulfillmentOrderId for the shopifyOrderId-->
+                <set field="fulfillmentOrderIdList" from="[]"/>
                 <if condition="fulfillmentOrderResponse.response.node.fulfillmentOrders.edges">
-                    <script>fulfillmentOrders.addAll(fulfillmentOrderResponse.response.node.fulfillmentOrders.edges.node)</script>
+                    <script>fulfillmentOrderIdList.addAll(fulfillmentOrderResponse.response.node.fulfillmentOrders.edges.node.id)</script>
                 </if>
-                <set field="fulfillmentOrderDetailsList" from="[]"/>
-                <set field="fulfillmentOrderIdList" from="fulfillmentOrders.id"/>
+<!--                Getting fulfillment order details for each fulfillmentOrderId-->
                 <iterate list="fulfillmentOrderIdList" entry="fulfillmentOrderId">
                     <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, fulfillmentOrderId:fulfillmentOrderId]" out-map="fulfillmentDetail"/>
-                    <script>fulfillmentOrderDetailsList.addAll(fulfillmentDetail.fulfillmentDetail)</script>
+                    <script>fulfillmentOrders.addAll(fulfillmentDetail.fulfillmentDetail)</script>
                 </iterate>
                 <set field="hasNextPage" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.endCursor"/>
             </while>
-            <set field="fulfillmentByOrderDetail.id" from="fulfillmentOrderResponse.response.node.id"/>
-            <set field="fulfillmentByOrderDetail.name" from="fulfillmentOrderResponse.response.node.name"/>
-            <set field="fulfillmentByOrderDetail.fulfillmentOrders" from="fulfillmentOrderDetailsList"/>
+            <set field="fulfillmentOrdersByOrderId.id" from="fulfillmentOrderResponse.response.node.id"/>
+            <set field="fulfillmentOrdersByOrderId.name" from="fulfillmentOrderResponse.response.node.name"/>
+            <set field="fulfillmentOrdersByOrderId.fulfillmentOrders" from="fulfillmentOrders"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -216,4 +216,32 @@ under the License.
                 remote ${systemMessageRemoteId}, saved response in messages ${shopifyFulfillmentAckOut.systemMessageId}"/>
         </actions>
     </service>
+    <service verb="get" noun="FulfillmentOrderDetails">
+        <description>Get fulfillment order details for a given fulfillmentOrder Id</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="fulfillmentOrderId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="fulfillmentOrderDetail"/>
+        </out-parameters>
+        <actions>
+            <script>
+                StringWriter sw = new StringWriter()
+                ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/graphQL/FulfillmentByIdQuery.ftl", sw)
+                queryText = sw.toString()
+                ec.logger.info ("=====queryText" + queryText)
+                try {
+                    sw.close()
+                } catch (IOException e) {
+                    ec.logger.error("Error closing StringWriter")
+                }
+            </script>
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderResponse"/>
+            <if condition="!fulfillmentOrderResponse.response.node">
+                <return type="warning" message="No Shopify order found for id: ${fulfillmentOrderId}"/>
+            </if>
+            <set field="fulfillmentOrderDetail" from="fulfillmentOrderResponse.response.node"/>
+        </actions>
+    </service>
 </services>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -216,17 +216,17 @@ under the License.
                 remote ${systemMessageRemoteId}, saved response in messages ${shopifyFulfillmentAckOut.systemMessageId}"/>
         </actions>
     </service>
-    <service verb="get" noun="FulfillmentDetails">
+    <service verb="get" noun="FulfillmentOrderDetails">
         <description>Get fulfillment details for the given fulfillmentOrderId</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="fulfillmentOrderId" required="true"/>
         </in-parameters>
         <out-parameters>
-            <parameter name="fulfillmentDetail"/>
+            <parameter name="fulfillmentOrderDetail"/>
         </out-parameters>
         <actions>
-            <set field="fulfillmentDetail" from="[:]"/>
+            <set field="fulfillmentOrderDetail" from="[:]"/>
             <script>
                 StringWriter sw = new StringWriter()
                 ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentOrderHeaderByIdQuery.ftl", sw)
@@ -242,7 +242,7 @@ under the License.
             <if condition="!fulfillmentResponse.response.node">
                 <return type="warning" message="No Shopify fulfillment order found for id: ${fulfillmentOrderId}"/>
             </if>
-            <set field="fulfillmentDetail" from="fulfillmentResponse.response.node"/>
+            <set field="fulfillmentOrderDetail" from="fulfillmentResponse.response.node"/>
 <!--            Getting Fulfillment LineItems details-->
             <set field="hasNextPage" type="Boolean" value="true"/>
             <set field="fulfillmentLineItems" from="[]"/>
@@ -265,7 +265,7 @@ under the License.
                 <set field="hasNextPage" from="fulfillmentLineItemResponse.response.node.lineItems.pageInfo.hasNextPage"/>
                 <set field="cursor" from="fulfillmentLineItemResponse.response.node.lineItems.pageInfo.endCursor"/>
             </while>
-            <set field="fulfillmentDetail.lineItems" from="fulfillmentLineItems"/>
+            <set field="fulfillmentOrderDetail.lineItems" from="fulfillmentLineItems"/>
         </actions>
     </service>
     <service verb="get" noun="FulfillmentOrdersByOrderId">
@@ -304,8 +304,8 @@ under the License.
                 </if>
 <!--                Getting fulfillment order details for each fulfillmentOrderId-->
                 <iterate list="fulfillmentOrderIdList" entry="fulfillmentOrderId">
-                    <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, fulfillmentOrderId:fulfillmentOrderId]" out-map="fulfillmentDetail"/>
-                    <script>fulfillmentOrders.addAll(fulfillmentDetail.fulfillmentDetail)</script>
+                    <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentOrderDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, fulfillmentOrderId:fulfillmentOrderId]" out-map="fulfillmentOrderDetail"/>
+                    <script>fulfillmentOrders.addAll(fulfillmentOrderDetail.fulfillmentOrderDetail)</script>
                 </iterate>
                 <set field="hasNextPage" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="fulfillmentOrderResponse.response.node.fulfillmentOrders.pageInfo.endCursor"/>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -240,7 +240,7 @@ under the License.
             </script>
             <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentResponse"/>
             <if condition="!fulfillmentResponse.response.node">
-                <return type="warning" message="No Shopify order found for id: ${fulfillmentOrderId}"/>
+                <return type="warning" message="No Shopify fulfillment order found for id: ${fulfillmentOrderId}"/>
             </if>
             <set field="fulfillmentDetail" from="fulfillmentResponse.response.node"/>
 <!--            Getting Fulfillment LineItems details-->
@@ -269,7 +269,7 @@ under the License.
         </actions>
     </service>
     <service verb="get" noun="FulfillmentByOrderDetails">
-        <description>Get fulfillment order details for a given fulfillmentOrder Id</description>
+        <description>Get all fulfillment order details for a given shopify order Id</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="shopifyOrderId" required="true"/>
@@ -295,7 +295,7 @@ under the License.
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderResponse"/>
                 <if condition="!fulfillmentOrderResponse.response.node">
-                    <return type="warning" message="No fulfillment order found for id: ${fulfillmentOrderId}"/>
+                    <return type="warning" message="No shopify order found for id: ${shopifyOrderId}"/>
                 </if>
                 <if condition="fulfillmentOrderResponse.response.node.fulfillmentOrders.edges">
                     <script>fulfillmentOrders.addAll(fulfillmentOrderResponse.response.node.fulfillmentOrders.edges.node)</script>

--- a/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
+++ b/service/co/hotwax/shopify/fulfillment/ShopifyFulfillmentServices.xml
@@ -228,7 +228,7 @@ under the License.
         <actions>
             <script>
                 StringWriter sw = new StringWriter()
-                ec.resource.ftlTemplateRenderer.render("dbresource://Shopify/template/graphQL/FulfillmentByIdQuery.ftl", sw)
+                ec.resource.ftlTemplateRenderer.render("dbresource://shopify/template/graphQL/FulfillmentByIdQuery.ftl", sw)
                 queryText = sw.toString()
                 ec.logger.info ("=====queryText" + queryText)
                 try {


### PR DESCRIPTION
**Service**:
* get#FulfillmentOrderDetails: Shopify graqhQL API integration service to return header and line item  details for a given Shopify fulfillmentOrderId.
* get#FulfillmentOrdersByOrderId: Shopify graqhQL API integration service to get return details of all fulfillmentOrderId for a given Shopify orderId

**Template**:
* FulfillmentOrderHeaderByIdQuery template for fetching header level details.
* FulfillmentOrderLineItemsByIdQuery template for fetching line item details
* FulfillmentOrdersByOrderIdQuery template for fetching all fulfillmentOrderId for a given shopify orderId.