### PR TITLE
Improved: Removed parameterName condition from queue#BulkQuerySystemMessage service.

### DIFF
--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -313,7 +313,6 @@ under the License.
         <actions>
             <set field="queryParams" from="[:]"/>
             <entity-find entity-name="moqui.service.message.SystemMessageTypeParameter" list="additionalParameters">
-                <econdition field-name="parameterName" operator="in" value="filterQuery,fromDateBuffer,thruDateBuffer"/>
                 <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId"/>
                 <econdition field-name="systemMessageRemoteId" operator="equals" from="systemMessageRemoteId"/>
             </entity-find>


### PR DESCRIPTION
Removed condition of parameterName from systemMessageTypeParameter query, to allow all the the parameters to be passed in context.