### PR TITLE
Added support to subscribe orders/create Shopify Webhook & Create Order in OMS

### DIFF
--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -816,4 +816,19 @@
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
         <parameters parameterName="runAsBatch" parameterValue="true"/>
     </moqui.service.job.ServiceJob>
+
+    <!-- SystemMessageType record for shopify ORDERS_CREATE webhook -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="OrdersCreate"
+                                             description="Shopify Orders Create Webhook"
+                                             parentTypeId="ShopifyWebhook"
+                                             sendServiceName="co.hotwax.shopify.webhook.ShopifyWebhookServices.send#WebhookSubscriptionSystemMessage"
+                                             sendPath="component://shopify-connector/template/graphQL/WebhookSubscriptionCreate.ftl"
+                                             consumeServiceName="co.hotwax.shopify.webhook.ShopifyWebhookServices.consume#OrdersCreateWebhookPayloadSystemMessage">
+        <parameters parameterName="topic" parameterValue="ORDERS_CREATE" systemMessageRemoteId=""/>
+        <parameters parameterName="resourceId" parameterValue="OrderTransformation" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <!-- Enumeration for mapping OrdersCreate SystemMessageType to orders/create shopify webhook topic -->
+    <moqui.basic.Enumeration description="Shopify Orders Create Webhook" enumId="OrdersCreate"
+                             enumTypeId="ShopifyMessageTypeEnum" enumCode="orders/create"/>
 </entity-facade-xml>

--- a/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
+++ b/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
@@ -325,4 +325,49 @@ under the License.
             </if>
         </actions>
     </service>
+    <service verb="consume" noun="OrdersCreateWebhookPayloadSystemMessage" authenticate="anonymous-all">
+        <description>Service to consume shopify webhook order payload, transform it and then call createShopifyOrder OMS API.</description>
+        <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+        <actions>
+            <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage">
+                <field-map field-name="systemMessageId"/>
+            </entity-find-one>
+            <!-- Pass the messageText to the service for Order JSON transformation -->
+            <if condition="systemMessage.messageText">
+                <!-- Fetch Groovy Script's location to transform the order Json -->
+                <entity-find-one entity-name="moqui.service.message.SystemMessageTypeParameter" value-field="transformationScriptLocation">
+                    <field-map field-name="systemMessageTypeId" from="systemMessage.systemMessageTypeId"/>
+                    <field-map field-name="parameterName" value="resourceId"/>
+                    <select-field field-name="parameterValue"/>
+                </entity-find-one>
+                <entity-find-one entity-name="moqui.resource.DbResource" value-field="transformationScript">
+                    <field-map field-name="resourceId" from="transformationScriptLocation.parameterValue"/>
+                </entity-find-one>
+                <!-- Return error if transformation script is not found -->
+                <if condition="!transformationScript">
+                    <return error="true" message=""/>
+                </if>
+
+                <set field="orderPayload" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
+                <service-call name="co.hotwax.ofbiz.OrderServices.transform#OrderJson"
+                              in-map="[orderPayload: orderPayload, filename:transformationScript.filename]"
+                              out-map="result"/>
+
+                <!-- Get the transformed Order JSON, Call OMS API to create the order -->
+                <!-- Fetch shopifyShopId from SystemMessageRemote.remoteId -->
+                <entity-find-one entity-name="moqui.service.message.SystemMessageRemote" value-field="shopifyShop" cache="true">
+                    <field-map field-name="systemMessageRemoteId" from="systemMessage.systemMessageRemoteId"/>
+                    <select-field field-name="remoteId"/>
+                </entity-find-one>
+                <service-call name="co.hotwax.ofbiz.OrderServices.send#CreateOrderRequest"
+                              in-map="[shopifyShopId: shopifyShop.remoteId, payload: result.transformedJson]"
+                              out-map="response"/>
+                <if condition="response &amp;&amp; response.orderId">
+                    <log level="info" message="Order created successfully with HC Order ID: ${response.orderId}"/>
+                    <service-call name="update#moqui.service.message.SystemMessage" transaction="force-new"
+                                  in-map="[systemMessageId:systemMessageId, orderId:response.orderId]"/>
+                </if>
+            </if>
+        </actions>
+    </service>
 </services>

--- a/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
+++ b/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
@@ -364,8 +364,8 @@ under the License.
                               out-map="response"/>
                 <if condition="response.response &amp;&amp; response.response.orderId">
                     <log level="info" message="Order created successfully with HC Order ID: ${response.response.orderId}"/>
-                    <service-call name="update#moqui.service.message.SystemMessage" transaction="force-new"
-                                  in-map="[systemMessageId:systemMessageId, orderId:response.response.orderId]"/>
+<!--                    <service-call name="update#moqui.service.message.SystemMessage" transaction="force-new"-->
+<!--                                  in-map="[systemMessageId:systemMessageId, orderId:response.response.orderId]"/>-->
                 </if>
             </if>
         </actions>

--- a/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
+++ b/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
@@ -32,8 +32,7 @@ under the License.
         <actions>
             <script>
                 if (!endPoint) endPoint = System.getProperty('shopify_webhook_end_point')
-               // endPoint = ec.web.getWebappRootUrl(true, false) + endPoint
-                endPoint = "https://dbj11nv7-8080.inc1.devtunnels.ms" + endPoint
+                endPoint = ec.web.getWebappRootUrl(true, false) + endPoint
                 StringWriter sw = new StringWriter()
                 ec.resource.ftlTemplateRenderer.render(templateLocation, sw)
                 queryText = sw.toString()

--- a/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
+++ b/service/co/hotwax/shopify/webhook/ShopifyWebhookServices.xml
@@ -32,7 +32,8 @@ under the License.
         <actions>
             <script>
                 if (!endPoint) endPoint = System.getProperty('shopify_webhook_end_point')
-                endPoint = ec.web.getWebappRootUrl(true, false) + endPoint
+               // endPoint = ec.web.getWebappRootUrl(true, false) + endPoint
+                endPoint = "https://dbj11nv7-8080.inc1.devtunnels.ms" + endPoint
                 StringWriter sw = new StringWriter()
                 ec.resource.ftlTemplateRenderer.render(templateLocation, sw)
                 queryText = sw.toString()
@@ -362,10 +363,10 @@ under the License.
                 <service-call name="co.hotwax.ofbiz.OrderServices.send#CreateOrderRequest"
                               in-map="[shopifyShopId: shopifyShop.remoteId, payload: result.transformedJson]"
                               out-map="response"/>
-                <if condition="response &amp;&amp; response.orderId">
-                    <log level="info" message="Order created successfully with HC Order ID: ${response.orderId}"/>
+                <if condition="response.response &amp;&amp; response.response.orderId">
+                    <log level="info" message="Order created successfully with HC Order ID: ${response.response.orderId}"/>
                     <service-call name="update#moqui.service.message.SystemMessage" transaction="force-new"
-                                  in-map="[systemMessageId:systemMessageId, orderId:response.orderId]"/>
+                                  in-map="[systemMessageId:systemMessageId, orderId:response.response.orderId]"/>
                 </if>
             </if>
         </actions>


### PR DESCRIPTION
- I have added the `SystemMessageType` data in the Upgrade Data file to subscribe ORDERS_CREATE (orders/create) Shopify Webhook.
- A custom consume service that works as follows:
   - Fetch Order JSON from the SystemMessage.messageText field.
   - Fetch Groovy script from the `dbresource` location to transform the order JSON as per the client's requirements.
   - Pass the transformed JSON by invoking the `createShopifyOrder` API to create the order in OMS.