### PR TITLE
Fix potential duplicate class loading issue causing memory leaks.

### DIFF
--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -60,7 +60,8 @@ under the License.
             <!-- Preparing the shopify url -->
             <if condition="endPoint">
                 <then>
-                    <set field="sendUrl" from="systemMessageRemote.sendUrl.endsWith('/') ? systemMessageRemote.sendUrl : systemMessageRemote.sendUrl+ '/'" />
+                    <set field="remoteSendUrl" from="systemMessageRemote.sendUrl.endsWith('/') ? systemMessageRemote.sendUrl : systemMessageRemote.sendUrl+ '/'" />
+                    <set field="sendUrl" from="ec.resourceFacade.expand(remoteSendUrl, null, ['shopifyApiVersion': System.getProperty('shopify_api_version')]"/>
                     <set field="shopifyUrl" from="sendUrl + endPoint"/>
                 </then>
                 <else-if condition="url">
@@ -71,7 +72,7 @@ under the License.
             <script><![CDATA[
                 import org.moqui.util.RestClient
 
-                shopifyUrl = ec.resourceFacade.expand(shopifyUrl, null, ["shopifyApiVersion": System.getProperty("shopify_api_version")])
+                //shopifyUrl = ec.resourceFacade.expand(shopifyUrl, null, ["shopifyApiVersion": System.getProperty("shopify_api_version")])
                 // Prepare RestClient and call Shopify API
                 RestClient restClient = ec.service.rest()
                 restClient.timeoutRetry(true);


### PR DESCRIPTION
The expand string method loads Groovy classes. It first checks the cache and, if not found, creates a new class loader each time. This behavior can lead to memory leaks when used improperly.

The Shopify URL may contain dynamic values, making it unsuitable for the expand method. The systemMessageRemote.sendUrl should use constant expressions that are reusable and appropriate for caching. Updated the code to modify systemMessageRemote.sendUrl by replacing the Shopify app version directly.