### PR TITLE
Added: Template and service to get the metafields for specific productId and namespaces

### DIFF
--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1524,4 +1524,50 @@
             <histories versionName="01" previousVersionName="01"/>
         </file>
     </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="ProductMetaFieldsByNameSpaceQuery.ftl" isFile="Y" resourceId="ProductMetaFieldsByNameSpaceQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                    query
+                    {
+                        node(id: "${shopifyProductId}") {
+                            id
+                                ... on
+                                Product {
+                                    id
+                                    metafields(namespace: "${namespace}", first: 10<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                        edges{
+                                            node{
+                                                id
+                                                key
+                                                namespace
+                                                value
+                                                type
+                                                reference {
+                                                    ... on Metaobject {
+                                                        id
+                                                        handle
+                                                        type
+                                                        fields {
+                                                            key
+                                                            value
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        pageInfo{
+                                            hasNextPage
+                                            endCursor
+                                        }
+                                    }
+                                }
+                            }
+                    }
+                </@compress>]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -300,7 +300,8 @@
                 </@compress>]]>
         </fileData>
     </moqui.resource.DbResourceFile>
-    <moqui.resource.DbResourceFile resourceId="ProductMetaFieldsByNameSpaceQuery">
+    <moqui.resource.DbResource filename="ProductMetaFieldsByNameSpaceQuery.ftl" isFile="Y" resourceId="ProductMetaFieldsByNameSpaceQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
                 <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
@@ -342,5 +343,7 @@
                     }
                 </@compress>]]>
             </fileData>
-    </moqui.resource.DbResourceFile>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade-upcoming">
+    <moqui.resource.DbResource filename="ProductMetaFieldsByNameSpaceQuery.ftl" isFile="Y" resourceId="ProductMetaFieldsByNameSpaceQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                    query
+                    {
+                        node(id: "${shopifyProductId}") {
+                            id
+                                ... on
+                                Product {
+                                    id
+                                    metafields(namespace: "${namespace}", first: 10<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                        edges{
+                                            node{
+                                                id
+                                                key
+                                                namespace
+                                                value
+                                                type
+                                                reference {
+                                                    ... on Metaobject {
+                                                        id
+                                                        handle
+                                                        type
+                                                        fields {
+                                                            key
+                                                            value
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        pageInfo{
+                                            hasNextPage
+                                            endCursor
+                                        }
+                                    }
+                                }
+                            }
+                    }
+                </@compress>]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
+</entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -201,7 +201,7 @@
                 ]]>
         </fileData>
     </moqui.resource.DbResourceFile>
-    <moqui.resource.DbResource resourceId="ProductByIdQuery">
+    <moqui.resource.DbResourceFile resourceId="ProductByIdQuery">
         <fileData>
             <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
@@ -240,8 +240,8 @@
                     }
                 </@compress>]]>
         </fileData>
-    </moqui.resource.DbResource>
-    <moqui.resource.DbResource resourceId="ProductVariantsByProductIdQuery">
+    </moqui.resource.DbResourceFile>
+    <moqui.resource.DbResourceFile resourceId="ProductVariantsByProductIdQuery">
         <fileData>
             <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
@@ -299,8 +299,8 @@
                     }
                 </@compress>]]>
         </fileData>
-    </moqui.resource.DbResource>
-    <moqui.resource.DbResource resourceId="ProductMetaFieldsByNameSpaceQuery">
+    </moqui.resource.DbResourceFile>
+    <moqui.resource.DbResourceFile resourceId="ProductMetaFieldsByNameSpaceQuery">
             <fileData>
                 <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
@@ -342,5 +342,5 @@
                     }
                 </@compress>]]>
             </fileData>
-    </moqui.resource.DbResource>
+    </moqui.resource.DbResourceFile>
 </entity-facade-xml>

--- a/service/co/hotwax/shopify/product/ShopifyProductServices.xml
+++ b/service/co/hotwax/shopify/product/ShopifyProductServices.xml
@@ -22,6 +22,7 @@ under the License.
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
             <parameter name="shopifyProductId" required="true"/>
+            <parameter name="namespaces" type="List"/>
         </in-parameters>
         <out-parameters>
             <parameter name="productDetail"/>
@@ -34,6 +35,18 @@ under the License.
             <if condition="!productResponse.response.node">
                 <return type="warning" message="No Shopify product found for id: ${shopifyProductId}"/>
             </if>
+
+            <if condition="namespaces">
+                <set field="metaFields" from="[]"/>
+                <iterate list="namespaces" entry="namespace">
+                    <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductMetaFields" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyProductId:shopifyProductId, namespace:namespace]"
+                                  out-map="productMetaFieldsOut"/>
+                    <script>
+                        metaFields.addAll(productMetaFieldsOut.productMetaFields)
+                    </script>
+                </iterate>
+            </if>
+
             <set field="hasNextPage" type="Boolean" value="true"/>
             <set field="productVariants" from="[]"/>
             <while condition="hasNextPage">
@@ -49,6 +62,45 @@ under the License.
             </while>
             <set field="productDetail" from="productResponse.response.node"/>
             <set field="productDetail.variants" from="productVariants"/>
+            <set field="productDetail.metaFields" from="metaFields"/>
+        </actions>
+    </service>
+
+    <service verb="get" noun="ProductMetaFields">
+        <description>Service to get Product Metafields for a productId and namespace.</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true">
+                <description>The System Message Remote Id to sned shopify request.</description>
+            </parameter>
+            <parameter name="shopifyProductId" required="true">
+                <description>Product Id to get metafields.</description>
+            </parameter>
+            <parameter name="namespace">
+                <description>Parameter to get metafields for specific namespace.</description>
+            </parameter>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="productMetaFields"/>
+        </out-parameters>
+        <actions>
+            <!-- Set the hasNextPage to true -->
+            <set field="hasNextPage" type="Boolean" value="true"/>
+
+            <!-- Initialize productMetaFields list -->
+            <set field="productMetaFields" from="[]"/>
+
+            <!-- If hasNextPage is true then send shopify graphql request to get the product metafields -->
+            <while condition="hasNextPage">
+                <script>
+                    queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/ProductMetaFieldsByNameSpaceQuery.ftl", "")
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="productMetaFieldResponse"/>
+                <if condition="productMetaFieldResponse.response.node.metafields.edges">
+                    <script>productMetaFields.addAll(productMetaFieldResponse.response.node.metafields.edges.node)</script>
+                </if>
+                <set field="hasNextPage" from="productMetaFieldResponse.response.node.metafields.pageInfo.hasNextPage"/>
+                <set field="cursor" from="productMetaFieldResponse.response.node.metafields.pageInfo.endCursor"/>
+            </while>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/product/ShopifyProductServices.xml
+++ b/service/co/hotwax/shopify/product/ShopifyProductServices.xml
@@ -37,12 +37,12 @@ under the License.
             </if>
 
             <if condition="namespaces">
-                <set field="metaFields" from="[]"/>
+                <set field="metafields" from="[]"/>
                 <iterate list="namespaces" entry="namespace">
-                    <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductMetaFields" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyProductId:shopifyProductId, namespace:namespace]"
-                                  out-map="productMetaFieldsOut"/>
+                    <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductMetafields" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyProductId:shopifyProductId, namespace:namespace]"
+                                  out-map="productMetafieldsOut"/>
                     <script>
-                        metaFields.addAll(productMetaFieldsOut.productMetaFields)
+                        metafields.addAll(productMetafieldsOut.productMetafields)
                     </script>
                 </iterate>
             </if>
@@ -62,11 +62,11 @@ under the License.
             </while>
             <set field="productDetail" from="productResponse.response.node"/>
             <set field="productDetail.variants" from="productVariants"/>
-            <set field="productDetail.metaFields" from="metaFields"/>
+            <set field="productDetail.metafields" from="metafields"/>
         </actions>
     </service>
 
-    <service verb="get" noun="ProductMetaFields">
+    <service verb="get" noun="ProductMetafields">
         <description>Service to get Product Metafields for a productId and namespace.</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true">
@@ -80,26 +80,26 @@ under the License.
             </parameter>
         </in-parameters>
         <out-parameters>
-            <parameter name="productMetaFields"/>
+            <parameter name="productMetafields"/>
         </out-parameters>
         <actions>
             <!-- Set the hasNextPage to true -->
             <set field="hasNextPage" type="Boolean" value="true"/>
 
-            <!-- Initialize productMetaFields list -->
-            <set field="productMetaFields" from="[]"/>
+            <!-- Initialize productMetafields list -->
+            <set field="productMetafields" from="[]"/>
 
             <!-- If hasNextPage is true then send shopify graphql request to get the product metafields -->
             <while condition="hasNextPage">
                 <script>
                     queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/ProductMetaFieldsByNameSpaceQuery.ftl", "")
                 </script>
-                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="productMetaFieldResponse"/>
-                <if condition="productMetaFieldResponse.response.node.metafields.edges">
-                    <script>productMetaFields.addAll(productMetaFieldResponse.response.node.metafields.edges.node)</script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="productMetafieldResponse"/>
+                <if condition="productMetafieldResponse.response.node.metafields.edges">
+                    <script>productMetafields.addAll(productMetafieldResponse.response.node.metafields.edges.node)</script>
                 </if>
-                <set field="hasNextPage" from="productMetaFieldResponse.response.node.metafields.pageInfo.hasNextPage"/>
-                <set field="cursor" from="productMetaFieldResponse.response.node.metafields.pageInfo.endCursor"/>
+                <set field="hasNextPage" from="productMetafieldResponse.response.node.metafields.pageInfo.hasNextPage"/>
+                <set field="cursor" from="productMetafieldResponse.response.node.metafields.pageInfo.endCursor"/>
             </while>
         </actions>
     </service>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -1427,6 +1427,7 @@ under the License.
                 </script>
                 <set field="createdProductIds" from="createdProductIdsResponse.response.products.edges.node"/>
                 <iterate list="createdProductIds" entry="productMap">
+                    <set field="productMap" from="productMap + [namespaces:queryParams.namespaces]"/>
                     <script>
                         new ObjectMapper()
                         .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
@@ -1516,7 +1517,7 @@ under the License.
             </script>
 
             <iterate list="products" entry="product">
-                <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyProductId:product.id]"
+                <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyProductId:product.id, namespaces:product.namespaces]"
                               out-map="productDetailsResponse" ignore-error="true" transaction="force-new"/>
 
                 <if condition="productDetailsResponse.productDetail">
@@ -1600,6 +1601,7 @@ under the License.
                 </script>
                 <set field="updatedProductIds" from="updatedProductIdsResponse.response.products.edges.node"/>
                 <iterate list="updatedProductIds" entry="productMap">
+                    <set field="productMap" from="productMap + [namespaces:queryParams.namespaces]"/>
                     <script>
                         new ObjectMapper()
                         .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
@@ -1689,7 +1691,7 @@ under the License.
             </script>
 
             <iterate list="products" entry="product">
-                <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyProductId:product.id]"
+                <service-call name="co.hotwax.shopify.product.ShopifyProductServices.get#ProductDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyProductId:product.id, namespaces:product.namespaces]"
                               out-map="productDetailsResponse" ignore-error="true" transaction="force-new"/>
 
                 <if condition="productDetailsResponse.productDetail">


### PR DESCRIPTION
1. Added the graphql template to get the metafields for a specific productId and namespace.
2. Added a service get#ProductMetaFields to get the metafields for a product.
3. Updated the generate#CreatedProductIds service to pass the namespace as well in the get#ProductDetails service
4. Updated the get#ProductDetails service to call get#ProductMetaFields service to get the metafields for a specific productId and namespace.