### PR TITLE
Impl: Fetch Closed Fulfillment Orders from Shopify

### DIFF
--- a/component.xml
+++ b/component.xml
@@ -17,6 +17,6 @@ under the License.
 -->
 
 <component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd"
-           name="shopify-connector" version="2.2.1">
+           name="shopify-connector" version="2.3.0">
     <!-- no dependencies -->
 </component>

--- a/data/ShopifyServiceJobData.xml
+++ b/data/ShopifyServiceJobData.xml
@@ -240,6 +240,12 @@ under the License.
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
         <parameters parameterName="runAsBatch" parameterValue="true"/>
     </moqui.service.job.ServiceJob>
+    <moqui.service.job.ServiceJob jobName="queue_FulfillmentOrderIdsFeed" description="Queue Fufillment Orders feed"
+                                  serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="GenerateFulfillmentOrderIdsFeed"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue="SHOP_CONFIG"/>
+        <parameters parameterName="runAsBatch" parameterValue="true"/>
+    </moqui.service.job.ServiceJob>
 
     <!-- ServiceJob data for queuing Updated productIds feed -->
     <moqui.basic.Enumeration enumId="QueueUpdatedProductsFeed" enumCode="QueueUpdatedProductsFeed" description="Queue Product Updates Feed" enumTypeId="PRODUCT_SYS_JOB"/>

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -628,6 +628,13 @@ under the License.
             consumeServiceName="">
     </moqui.service.message.SystemMessageType>
 
+    <!-- SystemMessageType record for generating Fulfillment Order Ids Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateFulfillmentOrderIdsFeed"
+             description="Shopify Fulfillment Order Ids Feed"
+             sendPath="dbresource://shopify/template/graphQL/FulfillmentOrderIdsQuery.ftl"
+             sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#FulfillmentOrderIdsFeed"
+             receivePath="${contentRoot}/shopify/FulfillmentOrderIdsFeed/FulfillmentOrderIdsFeed-${dateTime}-${systemMessageId}.json"/>
+
     <!-- Enumeration to create relation between GenerateUpdatedProductIdsFeed, GenerateProductUpdatesFeed and SendProductUpdatesFeed SystemMessageType(s) -->
     <moqui.basic.Enumeration description="Send Product Updates Feed" enumId="SendProductUpdatesFeed" enumTypeId="ShopifyMessageTypeEnum"/>
     <moqui.basic.Enumeration description="Generate Product Updates Feed" enumId="GenerateProductUpdatesFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendProductUpdatesFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -635,6 +635,15 @@ under the License.
              sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#FulfillmentOrderIdsFeed"
              receivePath="${contentRoot}/shopify/FulfillmentOrderIdsFeed/FulfillmentOrderIdsFeed-${dateTime}-${systemMessageId}.json"/>
 
+    <!-- SystemMessageType record for generating the Fulfillment Orders Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateFulfillmentOrdersFeed"
+             description="Shopify Fulfillment Orders Detail Feed"
+             parentTypeId="LocalFeedFile"
+             sendPath="${contentRoot}/shopify/FulfillmentOrdersFeed/FulfillmentOrdersFeed-${dateTime}-${systemMessageId}.json"
+             consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#FulfillmentOrdersFeed">
+        <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
     <!-- Enumeration to create relation between GenerateUpdatedProductIdsFeed, GenerateProductUpdatesFeed and SendProductUpdatesFeed SystemMessageType(s) -->
     <moqui.basic.Enumeration description="Send Product Updates Feed" enumId="SendProductUpdatesFeed" enumTypeId="ShopifyMessageTypeEnum"/>
     <moqui.basic.Enumeration description="Generate Product Updates Feed" enumId="GenerateProductUpdatesFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendProductUpdatesFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1577,4 +1577,38 @@
             <histories versionName="01" previousVersionName="01"/>
         </file>
     </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="FulfillmentOrderIdsQuery.ftl" isFile="Y" resourceId="FulfillmentOrderIdsQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}'"/>
+                        </#if>
+                        <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                            <#assign filterQuery = "updated_at:<'${queryParams.thruDate}'"/>
+                        </#if>
+                        <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND updated_at:<'${queryParams.thruDate}'"/>
+                        </#if>
+                        query {
+                            fulfillmentOrders (first: 100<#if cursor?has_content>, after: "${cursor}"</#if><#if filterQuery?has_content>, query: "${filterQuery}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    </@compress>
+                ]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -1594,7 +1594,7 @@
                             <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND updated_at:<'${queryParams.thruDate}'"/>
                         </#if>
                         query {
-                            fulfillmentOrders (first: 100<#if cursor?has_content>, after: "${cursor}"</#if><#if filterQuery?has_content>, query: "${filterQuery}"</#if>) {
+                            fulfillmentOrders (first: 100, includeClosed: true<#if cursor?has_content>, after: "${cursor}"</#if>, query: "status:'CLOSED'<#if filterQuery?has_content> AND ${filterQuery}"</#if>) {
                                 edges {
                                     node {
                                         id

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -397,6 +397,7 @@
                         ... on
                         FulfillmentOrder {
                             id
+                            orderId
                             status
                             createdAt
                             updatedAt

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -78,4 +78,97 @@
             </@compress>]]>
         </fileData>
     </moqui.resource.DbResourceFile>
+
+    <moqui.service.job.ServiceJob jobName="queue_FulfillmentOrderIdsFeed" description="Queue Fufillment Orders feed" serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="GenerateFulfillmentOrderIdsFeed"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue="SHOP_CONFIG"/>
+        <parameters parameterName="runAsBatch" parameterValue="true"/>
+    </moqui.service.job.ServiceJob>
+
+    <!-- SystemMessageType record for generating Fulfillment Order Ids Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateFulfillmentOrderIdsFeed"
+         description="Shopify Fulfillment Order Ids Feed"
+         sendPath="dbresource://shopify/template/graphQL/FulfillmentOrderIdsQuery.ftl"
+         sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#FulfillmentOrderIdsFeed"
+         receivePath="${contentRoot}/shopify/FulfillmentOrderIdsFeed/FulfillmentOrderIdsFeed-${dateTime}-${systemMessageId}.json"/>
+
+    <!-- SystemMessageType record for generating the Fulfillment Orders Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateFulfillmentOrdersFeed"
+         description="Shopify Fulfillment Orders Detail Feed"
+         parentTypeId="LocalFeedFile"
+         sendPath="${contentRoot}/shopify/FulfillmentOrdersFeed/FulfillmentOrdersFeed-${dateTime}-${systemMessageId}.json"
+         consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#FulfillmentOrdersFeed">
+        <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <moqui.resource.DbResource filename="FulfillmentOrderIdsQuery.ftl" isFile="Y" resourceId="FulfillmentOrderIdsQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}'"/>
+                        </#if>
+                        <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                            <#assign filterQuery = "updated_at:<'${queryParams.thruDate}'"/>
+                        </#if>
+                        <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND updated_at:<'${queryParams.thruDate}'"/>
+                        </#if>
+                        query {
+                            fulfillmentOrders (first: 100, includeClosed: true<#if cursor?has_content>, after: "${cursor}"</#if>, query: "status:'CLOSED'<#if filterQuery?has_content> AND ${filterQuery}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                    }
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    </@compress>
+                ]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
+
+    <moqui.resource.DbResource filename="FulfillmentOrderHeaderByIdQuery.ftl" isFile="Y" resourceId="FulfillmentOrderHeaderByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${fulfillmentOrderId}") {
+                        id
+                        ... on
+                        FulfillmentOrder {
+                            id
+                            orderId
+                            status
+                            createdAt
+                            updatedAt
+                            fulfillAt
+                            channelId
+                            assignedLocation {
+                                location {
+                                    id
+                                }
+                            }
+                            deliveryMethod {
+                                methodType
+                                serviceCode
+                            }
+                            createdAt
+                        }
+                    }
+                }
+                </@compress>]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
 </entity-facade-xml>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -1158,7 +1158,6 @@ under the License.
             <parameter name="runAsBatch" type="Boolean" default-value="false"/>
         </in-parameters>
         <actions>
-            <log message="1. ========================= ==============================="/>
             <set field="queryParams" from="[:]"/>
             <if condition="additionalParameters">
                 <set field="queryParams" from="additionalParameters"/>
@@ -1194,9 +1193,9 @@ under the License.
                                        messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams),  sendNow:true]"
                           out-map="queueSystemMessageOut"/>
 
-<!--            <if condition="runAsBatch">-->
-<!--                <service-call name="update#moqui.service.message.SystemMessage" in-map="[systemMessageId:queueSystemMessageOut.systemMessageId, messageDate:thruDate]"/>-->
-<!--            </if>-->
+            <if condition="runAsBatch">
+                <service-call name="update#moqui.service.message.SystemMessage" in-map="[systemMessageId:queueSystemMessageOut.systemMessageId, messageDate:thruDate]"/>
+            </if>
         </actions>
     </service>
     <service verb="generate" noun="UpdatedOrderIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
@@ -1986,9 +1985,7 @@ under the License.
                 import java.nio.charset.StandardCharsets
             </script>
             <set field="hasNextPage" type="Boolean" value="true"/>
-            <!-- TODO: Removing the iterationCount additional logic" -->
-            <set field="iterationCount" value="0" type="Integer"/>
-            <while condition="hasNextPage &amp;&amp; (iterationCount &lt; 1)">
+            <while condition="hasNextPage">
                 <script>queryText = ec.resourceFacade.template(systemMessage.sendPath, "")</script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderIdsResponse"/>
                 <if condition="!fulfillmentOrderIdsResponse.response.fulfillmentOrders.edges">
@@ -2032,7 +2029,6 @@ under the License.
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, parentMessageId:systemMessageId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
                 <set field="hasNextPage" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.endCursor"/>
-                <script>iterationCount+=1</script>
             </while>
         </actions>
     </service>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -1158,6 +1158,7 @@ under the License.
             <parameter name="runAsBatch" type="Boolean" default-value="false"/>
         </in-parameters>
         <actions>
+            <log message="1. ========================= ==============================="/>
             <set field="queryParams" from="[:]"/>
             <if condition="additionalParameters">
                 <set field="queryParams" from="additionalParameters"/>
@@ -1193,9 +1194,9 @@ under the License.
                                        messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams),  sendNow:true]"
                           out-map="queueSystemMessageOut"/>
 
-            <if condition="runAsBatch">
-                <service-call name="update#moqui.service.message.SystemMessage" in-map="[systemMessageId:queueSystemMessageOut.systemMessageId, messageDate:thruDate]"/>
-            </if>
+<!--            <if condition="runAsBatch">-->
+<!--                <service-call name="update#moqui.service.message.SystemMessage" in-map="[systemMessageId:queueSystemMessageOut.systemMessageId, messageDate:thruDate]"/>-->
+<!--            </if>-->
         </actions>
     </service>
     <service verb="generate" noun="UpdatedOrderIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
@@ -1968,6 +1969,70 @@ under the License.
                                        messageText:jsonFilePathRef, remoteMessageId: jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
                               out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
             </if>
+        </actions>
+    </service>
+    <service verb="generate" noun="FulfillmentOrderIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
+        <description>Generate the Fulfillment Order Ids Feed</description>
+        <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
+        <actions>
+            <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
+
+            <set field="queryParams" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
+
+            <script>
+                import com.fasterxml.jackson.core.JsonGenerator
+                import com.fasterxml.jackson.core.JsonFactory
+                import com.fasterxml.jackson.databind.ObjectMapper
+                import java.nio.charset.StandardCharsets
+            </script>
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <set field="iterationCount" value="0" type="Integer"/>
+            <while condition="hasNextPage &amp;&amp; (iterationCount &lt; 2)">
+                <script>queryText = ec.resourceFacade.template(systemMessage.sendPath, "")</script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderIdsResponse"/>
+                <if condition="!fulfillmentOrderIdsResponse.response.fulfillmentOrders.edges">
+                    <return message="No fulfillmentOrderIds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
+                </if>
+                <set field="nowDate" from="ec.user.nowTimestamp"/>
+                <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null,
+                    [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
+                <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+                <script>
+                    try {
+                        //json file
+                        File feedFile = new File(jsonFilePath)
+                        if (!feedFile.parentFile.exists()) feedFile.parentFile.mkdirs()
+                        JsonFactory jfactory = new JsonFactory()
+
+                        /* Declaring the PrintWriter and JsonGenerator resources in the try statement,
+                        so that they are automatically closed regardless of whether the try statement completes normally or abruptly. */
+                        try (PrintWriter pw = new PrintWriter(StandardCharsets.UTF_8, feedFile);
+                             JsonGenerator jGenerator = jfactory.createGenerator(pw)) {
+                            jGenerator.writeStartArray()
+                </script>
+                <set field="fulfillmentOrderIds" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.edges.node"/>
+                <iterate list="fulfillmentOrderIds" entry="fulfillmentOrderMap">
+                    <set field="fulfillmentOrderMap" from="fulfillmentOrderMap"/>
+                    <script>
+                        new ObjectMapper()
+                                .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
+                                .writerWithDefaultPrettyPrinter()
+                                .writeValue(jGenerator, fulfillmentOrderMap)
+                    </script>
+                </iterate>
+                <script>
+                    jGenerator.writeEndArray()
+                    }
+                    } catch (IOException e) {
+                        logger.error("Error preparing CreatedProductIds Feed file", e)
+                    }
+                </script>
+                <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:'GenerateCreatedProductsFeed', messageText:jsonFilePathRef,
+                              systemMessageRemoteId:systemMessage.systemMessageRemoteId, parentMessageId:systemMessageId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
+                <set field="hasNextPage" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.hasNextPage"/>
+                <set field="cursor" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.endCursor"/>
+                <script>iterationCount+=1</script>
+            </while>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -2010,7 +2010,6 @@ under the License.
                 </script>
                 <set field="fulfillmentOrderIds" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.edges.node"/>
                 <iterate list="fulfillmentOrderIds" entry="fulfillmentOrderMap">
-                    <set field="fulfillmentOrderMap" from="fulfillmentOrderMap"/>
                     <script>
                         new ObjectMapper()
                                 .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -2090,6 +2090,9 @@ under the License.
                     logger.error("Error preparing Created Products Feed file", e)
                 }
             </script>
+
+            <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:'ShopifyFulfillmentOrdersFeed', messageText:jsonFilePathRef,
+                      systemMessageRemoteId:systemMessage.systemMessageRemoteId, parentMessageId:systemMessageId, remoteMessageId: jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" async="true"/>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -1986,8 +1986,9 @@ under the License.
                 import java.nio.charset.StandardCharsets
             </script>
             <set field="hasNextPage" type="Boolean" value="true"/>
+            <!-- TODO: Removing the iterationCount additional logic" -->
             <set field="iterationCount" value="0" type="Integer"/>
-            <while condition="hasNextPage &amp;&amp; (iterationCount &lt; 2)">
+            <while condition="hasNextPage &amp;&amp; (iterationCount &lt; 1)">
                 <script>queryText = ec.resourceFacade.template(systemMessage.sendPath, "")</script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="fulfillmentOrderIdsResponse"/>
                 <if condition="!fulfillmentOrderIdsResponse.response.fulfillmentOrders.edges">
@@ -2027,12 +2028,68 @@ under the License.
                         logger.error("Error preparing CreatedProductIds Feed file", e)
                     }
                 </script>
-                <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:'GenerateCreatedProductsFeed', messageText:jsonFilePathRef,
+                <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:'GenerateFulfillmentOrdersFeed', messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, parentMessageId:systemMessageId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
                 <set field="hasNextPage" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="fulfillmentOrderIdsResponse.response.fulfillmentOrders.pageInfo.endCursor"/>
                 <script>iterationCount+=1</script>
             </while>
+        </actions>
+    </service>
+    <service verb="generate" noun="FulfillmentOrdersFeed" authenticate="anonymous-all" transaction-timeout="1800">
+        <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+        <actions>
+            <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
+
+            <set field="fileText" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
+            <set field="fulfillmentOrdersList" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(fileText, List.class)"/>
+
+            <if condition="!fulfillmentOrdersList">
+                <return type="warning" message="System message [${systemMessageId}] for Type [${systemMessage?.systemMessageTypeId}] has messageText [${systemMessage.messageText}], with ReturnedOrderIdsFeed file having incorrect data and may contain null, not generating order returns feed file."/>
+            </if>
+
+            <set field="nowDate" from="ec.user.nowTimestamp"/>
+            <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.sendPath, null,
+                    [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', date:ec.l10n.format(nowDate, 'yyyy-MM-dd'),
+                    dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
+            <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+
+            <script>
+                import com.fasterxml.jackson.core.JsonGenerator
+                import com.fasterxml.jackson.core.JsonFactory
+                import com.fasterxml.jackson.databind.ObjectMapper
+                import java.nio.charset.StandardCharsets
+
+                try {
+                    //json file
+                    File feedFile = new File(jsonFilePath)
+                    if (!feedFile.parentFile.exists()) feedFile.parentFile.mkdirs()
+                    JsonFactory jfactory = new JsonFactory()
+
+                    /* Declaring the PrintWriter and JsonGenerator resources in the try statement,
+                    so that they are automatically closed regardless of whether the try statement completes normally or abruptly. */
+                    try (PrintWriter pw = new PrintWriter(StandardCharsets.UTF_8, feedFile);
+                         JsonGenerator jGenerator = jfactory.createGenerator(pw)) {
+                        jGenerator.writeStartArray()
+            </script>
+            <iterate list="fulfillmentOrdersList" entry="fulfillmentOrder">
+                <service-call name="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.get#FulfillmentOrderDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, fulfillmentOrderId:fulfillmentOrder.id]"
+                              out-map="fufillmentOrderDetailsResponse" ignore-error="true" transaction="force-new"/>
+                <if condition="fufillmentOrderDetailsResponse.fulfillmentOrderDetail">
+                    <script>
+                        new ObjectMapper()
+                                .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
+                                .writerWithDefaultPrettyPrinter().writeValue(jGenerator, fufillmentOrderDetailsResponse.fulfillmentOrderDetail)
+                    </script>
+                </if>
+            </iterate>
+            <script>
+                jGenerator.writeEndArray()
+                }
+                } catch (IOException e) {
+                    logger.error("Error preparing Created Products Feed file", e)
+                }
+            </script>
         </actions>
     </service>
 </services>


### PR DESCRIPTION
**Ticket**: https://git.hotwax.co/commerce/oms/-/issues/398

Added logic to fetch closed Fulfillment Orders from Shopify.

This update adds logic to fetch CLOSED `fulfillmentOrders` from Shopify. The flow starts by retrieving fulfillment order IDs in batches of 100. Once the IDs are collected, the service fetches the required details for each one and processes only those marked as closed.