### PR TITLE
Updated the ServiceJob entity data

### DIFF
--- a/data/ShopifyServiceJobData.xml
+++ b/data/ShopifyServiceJobData.xml
@@ -31,7 +31,7 @@ under the License.
 
     <!-- ServiceJob data for polling OMS Fulfilled Items Feed -->
     <moqui.basic.Enumeration enumId="POL_OMS_FLFLMNT_FD" enumCode="POL_OMS_FLFLMNT_FD" description="Poll OMS Fulfilled Items Feed" enumTypeId="FULFILLMENT_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="poll_SystemMessageFileSftp_OMSFulfillmentFeed" jobTypeEnumId="POL_OMS_FLFLMNT_FD" description="Poll OMS Fulfilled Items Feed"
+    <moqui.service.job.ServiceJob jobName="poll_SystemMessageFileSftp_OMSFulfillmentFeed" jobTypeEnumId="POL_OMS_FLFLMNT_FD" instanceOfProductId="POL_OMS_FLFLMNT_FD" description="Poll OMS Fulfilled Items Feed"
             serviceName="co.hotwax.ofbiz.SystemMessageServices.poll#SystemMessageFileSftp" cronExpression="0 0 * * * ?" paused="Y">
         <parameters parameterName="systemMessageTypeId" parameterValue="OMSFulfillmentFeed"/>
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
@@ -39,7 +39,7 @@ under the License.
 
     <!-- ServiceJob data to send Shopify Fulfillment Ack Feed -->
     <moqui.basic.Enumeration enumId="SND_SHPFY_FUL_ACK_FD" enumCode="SND_SHPFY_FUL_ACK_FD" description="Send Shopify Fulfillment Ack Feed" enumTypeId="FULFILLMENT_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="sendShopifyFulfillmentAckFeed" jobTypeEnumId="SND_SHPFY_FUL_ACK_FD" description="Send Shopify Fulfillment Ack Feed"
+    <moqui.service.job.ServiceJob jobName="sendShopifyFulfillmentAckFeed" jobTypeEnumId="SND_SHPFY_FUL_ACK_FD" instanceOfProductId="SND_SHPFY_FUL_ACK_FD" description="Send Shopify Fulfillment Ack Feed"
             serviceName="co.hotwax.shopify.fulfillment.ShopifyFulfillmentServices.generate#ShopifyFulfillmentAckFeed" cronExpression="0 0 * * * ?" paused="Y">
         <parameters parameterName="sinceDate" parameterValue=""/>
         <parameters parameterName="jobName" parameterValue=""/>
@@ -78,7 +78,7 @@ under the License.
 
     <!-- ServiceJob data for sending next bulk query system message in queue-->
     <moqui.basic.Enumeration enumId="SND_BLK_SYS_M_SHPFY" enumCode="SND_BLK_SYS_M_SHPFY" description="Send next bulk query system message in queue" enumTypeId="MISC_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="send_ProducedBulkOperationSystemMessage_ShopifyBulkQuery" jobTypeEnumId="SND_BLK_SYS_M_SHPFY" description="Send next bulk query system message in queue"
+    <moqui.service.job.ServiceJob jobName="send_ProducedBulkOperationSystemMessage_ShopifyBulkQuery" jobTypeEnumId="SND_BLK_SYS_M_SHPFY" instanceOfProductId="SND_BLK_SYS_M_SHPFY" description="Send next bulk query system message in queue"
             serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.send#ProducedBulkOperationSystemMessage" cronExpression="0 0/15 * * * ?" paused="Y">
         <parameters parameterName="parentSystemMessageTypeId" parameterValue="ShopifyBulkQuery"/>
         <parameters parameterName="retryLimit" parameterValue=""/><!-- Defaults to 3 -->
@@ -92,7 +92,7 @@ under the License.
 
     <!-- ServiceJob data for polling current bulk operation query result -->
     <moqui.basic.Enumeration enumId="POL_BLK_RSLT_SHPFY" enumCode="POL_BLK_RSLT_SHPFY" description="Poll current bulk operation query result" enumTypeId="MISC_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="poll_BulkOperationResult_ShopifyBulkQuery" jobTypeEnumId="POL_BLK_RSLT_SHPFY" description="Poll current bulk operation query result"
+    <moqui.service.job.ServiceJob jobName="poll_BulkOperationResult_ShopifyBulkQuery" jobTypeEnumId="POL_BLK_RSLT_SHPFY" instanceOfProductId="POL_BLK_RSLT_SHPFY" description="Poll current bulk operation query result"
             serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.poll#BulkOperationResult" cronExpression="0 0/15 * * * ?" paused="Y">
         <parameters parameterName="parentSystemMessageTypeId" parameterValue="ShopifyBulkQuery"/>
     </moqui.service.job.ServiceJob>
@@ -234,7 +234,7 @@ under the License.
 
     <!-- ServiceJob data for queuing Created productIds feed -->
     <moqui.basic.Enumeration enumId="QueueCreatedProductsFeed" enumCode="QueueCreatedProductsFeed" description="Queue Created Products Feed" enumTypeId="PRODUCT_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="queue_CreatedProductIdsFeed" description="Queue created productIds feed" jobTypeEnumId="QueueCreatedProductsFeed"
+    <moqui.service.job.ServiceJob jobName="queue_CreatedProductIdsFeed" description="Queue created productIds feed" jobTypeEnumId="QueueCreatedProductsFeed" instanceOfProductId="QueueCreatedProductsFeed"
           serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
         <parameters parameterName="systemMessageTypeId" parameterValue="GenerateCreatedProductIdsFeed"/>
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
@@ -249,7 +249,7 @@ under the License.
 
     <!-- ServiceJob data for queuing Updated productIds feed -->
     <moqui.basic.Enumeration enumId="QueueUpdatedProductsFeed" enumCode="QueueUpdatedProductsFeed" description="Queue Product Updates Feed" enumTypeId="PRODUCT_SYS_JOB"/>
-    <moqui.service.job.ServiceJob jobName="queue_UpdatedProductIdsFeed" description="Queue updated productIds feed" jobTypeEnumId="QueueUpdatedProductsFeed"
+    <moqui.service.job.ServiceJob jobName="queue_UpdatedProductIdsFeed" description="Queue updated productIds feed" jobTypeEnumId="QueueUpdatedProductsFeed" instanceOfProductId="QueueUpdatedProductsFeed"
             serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
         <parameters parameterName="systemMessageTypeId" parameterValue="GenerateUpdatedProductIdsFeed"/>
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>


### PR DESCRIPTION
- Updated the `ServiceJob` entity data with `instanceOfProductId` field populated.
- The new version of job manager app will work on `ServiceJobAndProduct` model instead of `ServiceJobAndEnum` model.