### PR TITLE
Added: Appeasement Services to migrate createAppeasements flow to Maarg

### DIFF
--- a/component.xml
+++ b/component.xml
@@ -17,6 +17,6 @@ under the License.
 -->
 
 <component xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/moqui-conf-3.xsd"
-           name="shopify-connector" version="2.3.1">
+           name="shopify-connector" version="2.4.0">
     <!-- no dependencies -->
 </component>

--- a/data/ShopifyConfigDemoData.xml
+++ b/data/ShopifyConfigDemoData.xml
@@ -141,6 +141,19 @@
             sendPath=""/>
 
     <!-- Configure remote SFTP server against your shopify config for sending the feed -->
+    <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="GenerateAppeasementsFeed"
+            parameterName="sendSmrId"
+            parameterValue=""
+            systemMessageRemoteId=""/>
+
+    <!-- Configure SFTP file path in sendPath attribute -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendAppeasementsFeed"
+            description="Send Returns and Exchange Feed"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+    <!-- Configure remote SFTP server against your shopify config for sending the feed -->
     <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="GenerateNewOrdersFeed"
             parameterName="sendSmrId"
             parameterValue=""

--- a/data/ShopifyServiceJobData.xml
+++ b/data/ShopifyServiceJobData.xml
@@ -189,6 +189,15 @@ under the License.
         <parameters parameterName="thruDate" parameterValue=""/>
     </moqui.service.job.ServiceJob>
 
+    <!-- ServiceJob data for queuing Appeasement Ids feed -->
+    <moqui.service.job.ServiceJob jobName="queue_AppeasementIdsFeed" description="Queue Appeasement Ids feed"
+            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#AppeasementIdsFeed" cronExpression="0 0 * * * ?" paused="Y">
+        <parameters parameterName="systemMessageTypeId" parameterValue="GenerateAppeasementIdsFeed"/>
+        <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+        <parameters parameterName="fromDate" parameterValue=""/>
+        <parameters parameterName="thruDate" parameterValue=""/>
+    </moqui.service.job.ServiceJob>
+
     <!-- ServiceJob data for queuing orderIds by tag feed -->
     <moqui.service.job.ServiceJob jobName="queue_OrderIdsByTagFeed" description="Queue orderIds by tag feed"
             serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#OrderIdsByTagFeed" cronExpression="0 0 * * * ?" paused="Y">

--- a/data/ShopifyServiceJobData.xml
+++ b/data/ShopifyServiceJobData.xml
@@ -210,11 +210,10 @@ under the License.
 
     <!-- ServiceJob data for queuing Appeasement Ids feed -->
     <moqui.service.job.ServiceJob jobName="queue_AppeasementIdsFeed" description="Queue Appeasement Ids feed"
-            serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#AppeasementIdsFeed" cronExpression="0 0 * * * ?" paused="Y">
+        serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
         <parameters parameterName="systemMessageTypeId" parameterValue="GenerateAppeasementIdsFeed"/>
         <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
-        <parameters parameterName="fromDate" parameterValue=""/>
-        <parameters parameterName="thruDate" parameterValue=""/>
+        <parameters parameterName="runAsBatch" parameterValue="true"/>
     </moqui.service.job.ServiceJob>
 
     <!-- ServiceJob data for queuing orderIds by tag feed -->

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -441,7 +441,7 @@ under the License.
     <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementIdsFeed"
             description="Generate Appeasement Ids Feed"
             sendPath="dbresource://shopify/template/graphQL/AppeasementIdsQuery.ftl"
-            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementIdsFeed"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#RefundIdsFeed"
             receivePath="${contentRoot}/shopify/AppeasementIdsFeed/AppeasementIdsFeed-${dateTime}-${systemMessageId}.json"/>
 
 <!-- SystemMessageType record for generating Returns and Exchange Feed -->
@@ -449,7 +449,7 @@ under the License.
             description="Generate Appeasements Feed"
             parentTypeId="LocalFeedFile"
             sendPath="${contentRoot}/shopify/AppeasementsFeed/AppeasementsFeed-${dateTime}-${systemMessageId}.json"
-            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementsFeed">
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#RefundsFeed">
         <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
     </moqui.service.message.SystemMessageType>
 

--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -437,6 +437,33 @@ under the License.
     <moqui.basic.Enumeration description="Generate Returns And Exchange Feed" enumId="GenerateReturnsAndExchangeFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendReturnsAndExchangeFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
     <moqui.basic.Enumeration description="Generate Returned Order Ids Feed" enumId="GenerateReturnedOrderIdsFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="GenerateReturnsAndExchangeFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
 
+    <!-- SystemMessageType record for generating Appeasements Ids Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementIdsFeed"
+            description="Generate Appeasement Ids Feed"
+            sendPath="dbresource://shopify/template/graphQL/AppeasementIdsQuery.ftl"
+            sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementIdsFeed"
+            receivePath="${contentRoot}/shopify/AppeasementIdsFeed/AppeasementIdsFeed-${dateTime}-${systemMessageId}.json"/>
+
+<!-- SystemMessageType record for generating Returns and Exchange Feed -->
+    <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementsFeed"
+            description="Generate Appeasements Feed"
+            parentTypeId="LocalFeedFile"
+            sendPath="${contentRoot}/shopify/AppeasementsFeed/AppeasementsFeed-${dateTime}-${systemMessageId}.json"
+            consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementsFeed">
+        <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
+    </moqui.service.message.SystemMessageType>
+
+    <moqui.service.message.SystemMessageType systemMessageTypeId="SendAppeasementsFeed"
+            description="Send Appeasements Feed"
+            parentTypeId="LocalFeedFile"
+            sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+            sendPath=""/>
+
+<!-- Enumeration to create relation between GenerateAppeasementIdsFeed, GenerateAppeasementsFeed and SendAppeasementsFeed SystemMessageType(s) -->
+    <moqui.basic.Enumeration description="Send Appeasements Feed" enumId="SendAppeasementsFeed" enumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Generate Appeasements Feed" enumId="GenerateAppeasementsFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendAppeasementsFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+    <moqui.basic.Enumeration description="Generate Appeasement Ids Feed" enumId="GenerateAppeasementIdsFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="GenerateAppeasementsFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
     <!-- SystemMessageType record for bulk canceled order items query to Shopify -->
     <moqui.service.message.SystemMessageType systemMessageTypeId="BulkCanceledOrderItemsQuery"
             description="Bulk Canceled Order Items Query System Message"

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -441,25 +441,25 @@
                                     }
                                 }
                             }
-                            orderAdjustments (first: 10) {
+                            refundShippingLines (first: 10){
                                 edges{
                                     node{
-                                        reason
-                                        taxAmountSet{
+                                        id
+                                        subtotalAmountSet{
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
-                                            },
+                                            }
                                             shopMoney{
                                                 currencyCode
                                                 amount
                                             }
                                         }
-                                        amountSet{
+                                        taxAmountSet{
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
-                                            },
+                                            }
                                             shopMoney{
                                                 currencyCode
                                                 amount

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -354,6 +354,79 @@
             <histories versionName="01" previousVersionName="01"/>
         </file>
     </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="RefundsByIDQuery.ftl" isFile="Y" resourceId="RefundsByIDQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${shopifyOrderId}") {
+                        id
+                        ... on
+                        Refund {
+                            id
+                            order {
+                                id
+                            }
+                            createdAt
+                            note
+                            transactions (first: 10) {
+                                edges{
+                                    node{
+                                        status
+                                        amountSet{
+                                            shopMoney{
+                                                amount
+                                                currencyCode
+                                            }
+                                        }
+                                        reason
+                                    }
+                                }
+                            }
+                            refundLineItems (first: 10) {
+                                edges{
+                                    node{
+                                        id
+                                        restockType
+                                        lineItem {
+                                            id
+                                            quantity
+                                            variant {
+                                                id
+                                            }
+                                            fulfillableQuantity
+                                        }
+                                    }
+                                }
+                            }
+                            orderAdjustment (first: 10) {
+                                edges{
+                                    node{
+                                        reason
+                                        taxAmountSet{
+                                            shopMoney{
+                                                currencyCode
+                                                amount
+                                            }
+                                        }
+                                        amountSet{
+                                            shopMoney{
+                                                currencyCode
+                                                amount
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                </@compress>]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
     <moqui.resource.DbResource filename="FulfillmentOrdersByOrderIdQuery.ftl" isFile="Y" resourceId="FulfillmentOrdersByOrderIdQuery"
                                parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
@@ -526,6 +599,47 @@
                                         id
                                         name
                                         returnStatus
+                                    }
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    </@compress>
+                ]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="AppeasementIdsQuery.ftl" isFile="Y" resourceId="AppeasementIdsQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                            <#assign filterQuery = "updated_at:<'${queryParams.thruDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND updated_at:<'${queryParams.thruDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if !filterQuery?has_content>
+                            <#assign filterQuery = "financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED'"/>
+                        </#if>
+                        query {
+                            orders (first: 100<#if cursor?has_content>, after: "${cursor}"</#if><#if filterQuery?has_content>, query: "${filterQuery}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                        name
+                                        refunds (first: 10) {
+                                            id
+                                        }
                                     }
                                 }
                                 pageInfo {

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -368,6 +368,9 @@
                             order {
                                 id
                                 name
+                                customer {
+                                    id
+                                }
                             }
                             createdAt
                             note
@@ -396,6 +399,10 @@
                                             presentmentMoney{
                                                 amount
                                                 currencyCode
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                     }
@@ -408,6 +415,10 @@
                                             presentmentMoney{
                                                 amount
                                                 currencyCode
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                         id
@@ -435,10 +446,18 @@
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                         amountSet{
                                             presentmentMoney{
+                                                currencyCode
+                                                amount
+                                            },
+                                            shopMoney{
                                                 currencyCode
                                                 amount
                                             }

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -423,6 +423,9 @@
                                         }
                                         id
                                         restockType
+                                        location{
+                                            id
+                                        }
                                         lineItem {
                                             id
                                             quantity

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -192,6 +192,37 @@
             <histories versionName="01" previousVersionName="01"/>
         </file>
     </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="RefundHeaderByIdQuery.ftl" isFile="Y" resourceId="RefundHeaderByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${refundId}") {
+                        id
+                        ... on
+                        Refund {
+                            id
+                            createdAt
+                            note
+                            order {
+                                id
+                                name
+                                customer{
+                                    id
+                                }
+                            }
+                            return {
+                                id
+                            }
+                        }
+                    }
+                }
+                </@compress>]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
     <moqui.resource.DbResource filename="ReturnLineItemByIdQuery.ftl" isFile="Y" resourceId="ReturnLineItemByIdQuery" parentResourceId="GraphQL">
         <file mimeType="text/html" versionName="01" rootVersionName="01">
             <fileData>
@@ -344,128 +375,6 @@
                                 pageInfo{
                                     endCursor
                                     hasNextPage
-                                }
-                            }
-                        }
-                    }
-                }
-                </@compress>]]>
-            </fileData>
-            <histories versionName="01" previousVersionName="01"/>
-        </file>
-    </moqui.resource.DbResource>
-    <moqui.resource.DbResource filename="RefundsByIDQuery.ftl" isFile="Y" resourceId="RefundsByIDQuery" parentResourceId="GraphQL">
-        <file mimeType="text/html" versionName="01" rootVersionName="01">
-            <fileData>
-                <![CDATA[<#ftl output_format="HTML">
-                <@compress single_line=true>
-                query{
-                    node(id: "${shopifyRefundId}") {
-                        id
-                        ... on
-                        Refund {
-                            id
-                            order {
-                                id
-                                name
-                                customer {
-                                    id
-                                }
-                            }
-                            createdAt
-                            note
-                            return{
-                                id
-                            }
-                            transactions (first: 10) {
-                                edges{
-                                    node{
-                                        id
-                                        gateway
-                                        processedAt
-                                        status
-                                        kind
-                                        parentTransaction{
-                                            id
-                                        }
-                                        receiptJson
-                                        paymentDetails {
-                                            ... on CardPaymentDetails {
-                                                paymentMethodName
-                                                company
-                                            }
-                                        }
-                                        amountSet{
-                                            presentmentMoney{
-                                                amount
-                                                currencyCode
-                                            },
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            refundLineItems (first: 10) {
-                                edges{
-                                    node{
-                                        totalTaxSet{
-                                            presentmentMoney{
-                                                amount
-                                                currencyCode
-                                            },
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                        id
-                                        restockType
-                                        location{
-                                            id
-                                        }
-                                        lineItem {
-                                            id
-                                            quantity
-                                            variant {
-                                                id
-                                            }
-                                            product {
-                                                id
-                                                title
-                                            }
-                                            fulfillableQuantity
-                                        }
-                                    }
-                                }
-                            }
-                            refundShippingLines (first: 10){
-                                edges{
-                                    node{
-                                        id
-                                        subtotalAmountSet{
-                                            presentmentMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                        taxAmountSet{
-                                            presentmentMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -686,7 +595,7 @@
                                     node {
                                         id
                                         name
-                                        refunds (first: 10) {
+                                        refunds {
                                             id
                                         }
                                     }
@@ -758,12 +667,25 @@
                                             node {
                                                 lineItem {
                                                     id
+                                                    variant {
+                                                        id
+                                                    }
                                                 }
                                                 location {
                                                     id
                                                 }
                                                 restockType
                                                 quantity
+                                                totalTaxSet{
+                                                    presentmentMoney{
+                                                        amount
+                                                        currencyCode
+                                                    },
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                }
                                             }
                                         }
                                         pageInfo {
@@ -815,6 +737,58 @@
                                                 paymentDetails {
                                                     ... on CardPaymentDetails {
                                                         company
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        pageInfo {
+                                            endCursor
+                                            hasNextPage
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    </@compress>
+                ]]>
+            </fileData>
+            <histories versionName="01" previousVersionName="01"/>
+        </file>
+    </moqui.resource.DbResource>
+    <moqui.resource.DbResource filename="RefundShippingLinesByIdQuery.ftl" isFile="Y" resourceId="RefundShippingLinesByIdQuery" parentResourceId="GraphQL">
+        <file mimeType="text/html" versionName="01" rootVersionName="01">
+            <fileData>
+                <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        query {
+                            node(id: "${shopifyRefundId}") {
+                                id
+                                ... on
+                                Refund {
+                                    id
+                                    refundShippingLines (first : 10<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                        edges {
+                                            node{
+                                                id
+                                                subtotalAmountSet{
+                                                    presentmentMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                }
+                                                taxAmountSet{
+                                                    presentmentMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
                                                     }
                                                 }
                                             }

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -360,7 +360,7 @@
                 <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
                 query{
-                    node(id: "${shopifyOrderId}") {
+                    node(id: "${shopifyRefundId}") {
                         id
                         ... on
                         Refund {
@@ -380,7 +380,7 @@
                                                 currencyCode
                                             }
                                         }
-                                        reason
+                                        kind
                                     }
                                 }
                             }
@@ -400,7 +400,7 @@
                                     }
                                 }
                             }
-                            orderAdjustment (first: 10) {
+                            orderAdjustments (first: 10) {
                                 edges{
                                     node{
                                         reason

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -367,26 +367,36 @@
                             id
                             order {
                                 id
+                                name
                             }
                             createdAt
                             note
+                            return{
+                                id
+                            }
                             transactions (first: 10) {
                                 edges{
                                     node{
                                         status
+                                        kind
                                         amountSet{
-                                            shopMoney{
+                                            presentmentMoney{
                                                 amount
                                                 currencyCode
                                             }
                                         }
-                                        kind
                                     }
                                 }
                             }
                             refundLineItems (first: 10) {
                                 edges{
                                     node{
+                                        totalTaxSet{
+                                            presentmentMoney{
+                                                amount
+                                                currencyCode
+                                            }
+                                        }
                                         id
                                         restockType
                                         lineItem {
@@ -394,6 +404,10 @@
                                             quantity
                                             variant {
                                                 id
+                                            }
+                                            product {
+                                                id
+                                                title
                                             }
                                             fulfillableQuantity
                                         }
@@ -405,13 +419,13 @@
                                     node{
                                         reason
                                         taxAmountSet{
-                                            shopMoney{
+                                            presentmentMoney{
                                                 currencyCode
                                                 amount
                                             }
                                         }
                                         amountSet{
-                                            shopMoney{
+                                            presentmentMoney{
                                                 currencyCode
                                                 amount
                                             }

--- a/data/ShopifyTemplateData.xml
+++ b/data/ShopifyTemplateData.xml
@@ -377,8 +377,21 @@
                             transactions (first: 10) {
                                 edges{
                                     node{
+                                        id
+                                        gateway
+                                        processedAt
                                         status
                                         kind
+                                        parentTransaction{
+                                            id
+                                        }
+                                        receiptJson
+                                        paymentDetails {
+                                            ... on CardPaymentDetails {
+                                                paymentMethodName
+                                                company
+                                            }
+                                        }
                                         amountSet{
                                             presentmentMoney{
                                                 amount

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -129,25 +129,25 @@
                                     }
                                 }
                             }
-                            orderAdjustments (first: 10) {
+                            refundShippingLines (first: 10){
                                 edges{
                                     node{
-                                        reason
-                                        taxAmountSet{
+                                        id
+                                        subtotalAmountSet{
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
-                                            },
+                                            }
                                             shopMoney{
                                                 currencyCode
                                                 amount
                                             }
                                         }
-                                        amountSet{
+                                        taxAmountSet{
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
-                                            },
+                                            }
                                             shopMoney{
                                                 currencyCode
                                                 amount

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -25,7 +25,7 @@
                                     node {
                                         id
                                         name
-                                        refunds (first: 10) {
+                                        refunds {
                                             id
                                         }
                                     }
@@ -42,119 +42,165 @@
       <histories versionName="01" previousVersionName="01"/>
     </file>
   </moqui.resource.DbResource>
-  <moqui.resource.DbResource filename="RefundsByIDQuery.ftl" isFile="Y" resourceId="RefundsByIDQuery" parentResourceId="GraphQL">
+
+  <moqui.resource.DbResource filename="RefundHeaderByIdQuery.ftl" isFile="Y" resourceId="RefundHeaderByIdQuery" parentResourceId="GraphQL">
     <file mimeType="text/html" versionName="01" rootVersionName="01">
       <fileData>
         <![CDATA[<#ftl output_format="HTML">
                 <@compress single_line=true>
                 query{
-                    node(id: "${shopifyRefundId}") {
+                    node(id: "${refundId}") {
                         id
                         ... on
                         Refund {
                             id
+                            createdAt
+                            note
                             order {
                                 id
                                 name
-                                customer {
+                                customer{
                                     id
                                 }
                             }
-                            createdAt
-                            note
-                            return{
+                            return {
                                 id
                             }
-                            transactions (first: 10) {
-                                edges{
-                                    node{
-                                        id
-                                        gateway
-                                        processedAt
-                                        status
-                                        kind
-                                        parentTransaction{
-                                            id
-                                        }
-                                        receiptJson
-                                        paymentDetails {
-                                            ... on CardPaymentDetails {
-                                                paymentMethodName
-                                                company
+                        }
+                    }
+                }
+                </@compress>]]>
+      </fileData>
+      <histories versionName="01" previousVersionName="01"/>
+    </file>
+  </moqui.resource.DbResource>
+  <moqui.resource.DbResource filename="RefundLineItemsByIdQuery.ftl" isFile="Y" resourceId="RefundLineItemsByIdQuery" parentResourceId="GraphQL">
+    <file mimeType="text/html" versionName="01" rootVersionName="01">
+      <fileData>
+        <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        query {
+                            node(id: "${shopifyRefundId}") {
+                                id
+                                ... on
+                                Refund {
+                                    id
+                                    refundLineItems (first : 10<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                        edges {
+                                            node {
+                                                lineItem {
+                                                    id
+                                                    variant {
+                                                        id
+                                                    }
+                                                }
+                                                location {
+                                                    id
+                                                }
+                                                restockType
+                                                quantity
+                                                totalTaxSet{
+                                                    presentmentMoney{
+                                                        amount
+                                                        currencyCode
+                                                    },
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                }
                                             }
                                         }
-                                        amountSet{
-                                            presentmentMoney{
-                                                amount
-                                                currencyCode
-                                            },
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            refundLineItems (first: 10) {
-                                edges{
-                                    node{
-                                        totalTaxSet{
-                                            presentmentMoney{
-                                                amount
-                                                currencyCode
-                                            },
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                        }
-                                        id
-                                        restockType
-                                        location{
-                                            id
-                                        }
-                                        lineItem {
-                                            id
-                                            quantity
-                                            variant {
-                                                id
-                                            }
-                                            product {
-                                                id
-                                                title
-                                            }
-                                            fulfillableQuantity
+                                        pageInfo {
+                                            hasNextPage
+                                            endCursor
                                         }
                                     }
                                 }
                             }
-                            refundShippingLines (first: 10){
-                                edges{
-                                    node{
-                                        id
-                                        subtotalAmountSet{
-                                            presentmentMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                            shopMoney{
-                                                currencyCode
-                                                amount
+                        }
+                    </@compress>
+                ]]>
+      </fileData>
+      <histories versionName="01" previousVersionName="01"/>
+    </file>
+  </moqui.resource.DbResource>
+  <moqui.resource.DbResource filename="RefundShippingLinesByIdQuery.ftl" isFile="Y" resourceId="RefundShippingLinesByIdQuery" parentResourceId="GraphQL">
+    <file mimeType="text/html" versionName="01" rootVersionName="01">
+      <fileData>
+        <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        query {
+                            node(id: "${shopifyRefundId}") {
+                                id
+                                ... on
+                                Refund {
+                                    id
+                                    refundShippingLines (first : 10<#if cursor?has_content>, after: "${cursor}"</#if>) {
+                                        edges {
+                                            node{
+                                                id
+                                                subtotalAmountSet{
+                                                    presentmentMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                }
+                                                taxAmountSet{
+                                                    presentmentMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                    shopMoney{
+                                                        currencyCode
+                                                        amount
+                                                    }
+                                                }
                                             }
                                         }
-                                        taxAmountSet{
-                                            presentmentMoney{
-                                                currencyCode
-                                                amount
-                                            }
-                                            shopMoney{
-                                                currencyCode
-                                                amount
-                                            }
+                                        pageInfo {
+                                            endCursor
+                                            hasNextPage
                                         }
                                     }
                                 }
+                            }
+                        }
+                    </@compress>
+                ]]>
+      </fileData>
+      <histories versionName="01" previousVersionName="01"/>
+    </file>
+  </moqui.resource.DbResource>
+  <moqui.resource.DbResource filename="RefundHeaderByIdQuery.ftl" isFile="Y" resourceId="RefundHeaderByIdQuery" parentResourceId="GraphQL">
+    <file mimeType="text/html" versionName="01" rootVersionName="01">
+      <fileData>
+        <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${returnId}") {
+                        id
+                        ... on
+                        Refund {
+                            id
+                            createdAt
+                            note
+                            name
+                            order {
+                                id
+                                name
+                                customer{
+                                    id
+                                }
+                            }
+                            return {
+                                id
                             }
                         }
                     }
@@ -167,25 +213,25 @@
 
   <!-- SystemMessageType record for generating Appeasement Ids Feed -->
   <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementIdsFeed"
-                                           description="Generate Appeasement Ids Feed"
-                                           sendPath="dbresource://shopify/template/graphQL/AppeasementIdsQuery.ftl"
-                                           sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementIdsFeed"
-                                           receivePath="${contentRoot}/shopify/AppeasementIdsFeed/AppeasementIdsFeed-${dateTime}-${systemMessageId}.json"/>
+    description="Generate Appeasement Ids Feed"
+    sendPath="dbresource://shopify/template/graphQL/AppeasementIdsQuery.ftl"
+    sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#RefundIdsFeed"
+    receivePath="${contentRoot}/shopify/AppeasementIdsFeed/AppeasementIdsFeed-${dateTime}-${systemMessageId}.json"/>
 
   <!-- SystemMessageType record for generating Appeasements Feed -->
   <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementsFeed"
-                                           description="Generate Appeasements Feed"
-                                           parentTypeId="LocalFeedFile"
-                                           sendPath="${contentRoot}/shopify/AppeasementsFeed/AppeasementsFeed-${dateTime}-${systemMessageId}.json"
-                                           consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementsFeed">
+    description="Generate Appeasements Feed"
+    parentTypeId="LocalFeedFile"
+    sendPath="${contentRoot}/shopify/AppeasementsFeed/AppeasementsFeed-${dateTime}-${systemMessageId}.json"
+    consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#RefundsFeed">
     <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
   </moqui.service.message.SystemMessageType>
 
   <moqui.service.message.SystemMessageType systemMessageTypeId="SendAppeasementsFeed"
-                                           description="Send Appeasements Feed"
-                                           parentTypeId="LocalFeedFile"
-                                           sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
-                                           sendPath=""/>
+    description="Send Appeasements Feed"
+    parentTypeId="LocalFeedFile"
+    sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+    sendPath=""/>
 
   <!-- Enumeration to create relation between GenerateAppeasementIdsFeed, GenerateAppeasementsFeed and SendAppeasementsFeed SystemMessageType(s) -->
   <moqui.basic.Enumeration description="Send Appeasements Feed" enumId="SendAppeasementsFeed" enumTypeId="ShopifyMessageTypeEnum"/>
@@ -194,11 +240,10 @@
 
   <!-- ServiceJob data for queuing Appeasement Ids feed -->
   <moqui.service.job.ServiceJob jobName="queue_AppeasementIdsFeed" description="Queue Appeasement Ids feed"
-                                serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#AppeasementIdsFeed" cronExpression="0 0 * * * ?" paused="Y">
+    serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#FeedSystemMessage" cronExpression="0 0 * * * ?" paused="Y">
     <parameters parameterName="systemMessageTypeId" parameterValue="GenerateAppeasementIdsFeed"/>
     <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
-    <parameters parameterName="fromDate" parameterValue=""/>
-    <parameters parameterName="thruDate" parameterValue=""/>
+    <parameters parameterName="runAsBatch" parameterValue="true"/>
   </moqui.service.job.ServiceJob>
 
   <ProductCategoryMember fromDate="2024-01-01 00:00:00.0" productCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT"/>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -201,12 +201,6 @@
     <parameters parameterName="thruDate" parameterValue=""/>
   </moqui.service.job.ServiceJob>
 
-  <!-- Configure remote SFTP server against your shopify config for sending the feed -->
-  <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="GenerateAppeasementsFeed"
-                                                    parameterName="sendSmrId"
-                                                    parameterValue=""
-                                                    systemMessageRemoteId=""/>
-
   <ProductCategoryMember fromDate="2024-01-01 00:00:00.0" productCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT"/>
   <Product description="Create Appeasement from Shopify" internalName="JOB_CRT_APPEASEMENT" isVariant="N" isVirtual="N" primaryProductCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT" productName="Create Appeasement" productTypeId="SERVICE"/>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade-upcoming">
+<!--  Shopify GraphQl Template to request data from shopify -->
+  <moqui.resource.DbResource filename="AppeasementIdsQuery.ftl" isFile="Y" resourceId="AppeasementIdsQuery" parentResourceId="GraphQL">
+    <file mimeType="text/html" versionName="01" rootVersionName="01">
+      <fileData>
+        <![CDATA[
+                    <#ftl output_format="HTML">
+                    <@compress single_line=true>
+                        <#if queryParams.fromDate?has_content && !queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if queryParams.thruDate?has_content && !queryParams.fromDate?has_content>
+                            <#assign filterQuery = "updated_at:<'${queryParams.thruDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if queryParams.fromDate?has_content && queryParams.thruDate?has_content>
+                            <#assign filterQuery = "updated_at:>'${queryParams.fromDate}' AND updated_at:<'${queryParams.thruDate}' AND (financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED')"/>
+                        </#if>
+                        <#if !filterQuery?has_content>
+                            <#assign filterQuery = "financial_status:'PARTIALLY_REFUNDED' OR financial_status:'REFUNDED'"/>
+                        </#if>
+                        query {
+                            orders (first: 100<#if cursor?has_content>, after: "${cursor}"</#if><#if filterQuery?has_content>, query: "${filterQuery}"</#if>) {
+                                edges {
+                                    node {
+                                        id
+                                        name
+                                        refunds (first: 10) {
+                                            id
+                                        }
+                                    }
+                                }
+                                pageInfo {
+                                    endCursor
+                                    hasNextPage
+                                }
+                            }
+                        }
+                    </@compress>
+                ]]>
+      </fileData>
+      <histories versionName="01" previousVersionName="01"/>
+    </file>
+  </moqui.resource.DbResource>
+  <moqui.resource.DbResource filename="RefundsByIDQuery.ftl" isFile="Y" resourceId="RefundsByIDQuery" parentResourceId="GraphQL">
+    <file mimeType="text/html" versionName="01" rootVersionName="01">
+      <fileData>
+        <![CDATA[<#ftl output_format="HTML">
+                <@compress single_line=true>
+                query{
+                    node(id: "${shopifyRefundId}") {
+                        id
+                        ... on
+                        Refund {
+                            id
+                            order {
+                                id
+                                name
+                            }
+                            createdAt
+                            note
+                            return{
+                                id
+                            }
+                            transactions (first: 10) {
+                                edges{
+                                    node{
+                                        status
+                                        kind
+                                        amountSet{
+                                            presentmentMoney{
+                                                amount
+                                                currencyCode
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            refundLineItems (first: 10) {
+                                edges{
+                                    node{
+                                        totalTaxSet{
+                                            presentmentMoney{
+                                                amount
+                                                currencyCode
+                                            }
+                                        }
+                                        id
+                                        restockType
+                                        lineItem {
+                                            id
+                                            quantity
+                                            variant {
+                                                id
+                                            }
+                                            product {
+                                                id
+                                                title
+                                            }
+                                            fulfillableQuantity
+                                        }
+                                    }
+                                }
+                            }
+                            orderAdjustments (first: 10) {
+                                edges{
+                                    node{
+                                        reason
+                                        taxAmountSet{
+                                            presentmentMoney{
+                                                currencyCode
+                                                amount
+                                            }
+                                        }
+                                        amountSet{
+                                            presentmentMoney{
+                                                currencyCode
+                                                amount
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                </@compress>]]>
+      </fileData>
+      <histories versionName="01" previousVersionName="01"/>
+    </file>
+  </moqui.resource.DbResource>
+
+  <!-- SystemMessageType record for generating Appeasement Ids Feed -->
+  <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementIdsFeed"
+                                           description="Generate Appeasement Ids Feed"
+                                           sendPath="dbresource://shopify/template/graphQL/AppeasementIdsQuery.ftl"
+                                           sendServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementIdsFeed"
+                                           receivePath="${contentRoot}/shopify/AppeasementIdsFeed/AppeasementIdsFeed-${dateTime}-${systemMessageId}.json"/>
+
+  <!-- SystemMessageType record for generating Appeasements Feed -->
+  <moqui.service.message.SystemMessageType systemMessageTypeId="GenerateAppeasementsFeed"
+                                           description="Generate Appeasements Feed"
+                                           parentTypeId="LocalFeedFile"
+                                           sendPath="${contentRoot}/shopify/AppeasementsFeed/AppeasementsFeed-${dateTime}-${systemMessageId}.json"
+                                           consumeServiceName="co.hotwax.shopify.system.ShopifySystemMessageServices.generate#AppeasementsFeed">
+    <parameters parameterName="sendSmrId" parameterValue="" systemMessageRemoteId=""/>
+  </moqui.service.message.SystemMessageType>
+
+  <moqui.service.message.SystemMessageType systemMessageTypeId="SendAppeasementsFeed"
+                                           description="Send Appeasements Feed"
+                                           parentTypeId="LocalFeedFile"
+                                           sendServiceName="co.hotwax.ofbiz.SystemMessageServices.send#SystemMessageFileSftp"
+                                           sendPath=""/>
+
+  <!-- Enumeration to create relation between GenerateAppeasementIdsFeed, GenerateAppeasementsFeed and SendAppeasementsFeed SystemMessageType(s) -->
+  <moqui.basic.Enumeration description="Send Appeasements Feed" enumId="SendAppeasementsFeed" enumTypeId="ShopifyMessageTypeEnum"/>
+  <moqui.basic.Enumeration description="Generate Appeasements Feed" enumId="GenerateAppeasementsFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="SendAppeasementsFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+  <moqui.basic.Enumeration description="Generate Appeasement Ids Feed" enumId="GenerateAppeasementIdsFeed" enumTypeId="ShopifyMessageTypeEnum" relatedEnumId="GenerateAppeasementsFeed" relatedEnumTypeId="ShopifyMessageTypeEnum"/>
+
+  <!-- ServiceJob data for queuing Appeasement Ids feed -->
+  <moqui.service.job.ServiceJob jobName="queue_AppeasementIdsFeed" description="Queue Appeasement Ids feed"
+                                serviceName="co.hotwax.shopify.system.ShopifySystemMessageServices.queue#AppeasementIdsFeed" cronExpression="0 0 * * * ?" paused="Y">
+    <parameters parameterName="systemMessageTypeId" parameterValue="GenerateAppeasementIdsFeed"/>
+    <parameters parameterName="systemMessageRemoteId" parameterValue=""/>
+    <parameters parameterName="fromDate" parameterValue=""/>
+    <parameters parameterName="thruDate" parameterValue=""/>
+  </moqui.service.job.ServiceJob>
+
+</entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -111,6 +111,9 @@
                                         }
                                         id
                                         restockType
+                                        location{
+                                            id
+                                        }
                                         lineItem {
                                             id
                                             quantity

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -166,4 +166,9 @@
     <parameters parameterName="thruDate" parameterValue=""/>
   </moqui.service.job.ServiceJob>
 
+  <!-- Configure remote SFTP server against your shopify config for sending the feed -->
+  <moqui.service.message.SystemMessageTypeParameter systemMessageTypeId="GenerateAppeasementsFeed"
+                                                    parameterName="sendSmrId"
+                                                    parameterValue=""
+                                                    systemMessageRemoteId=""/>
 </entity-facade-xml>

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -56,6 +56,9 @@
                             order {
                                 id
                                 name
+                                customer {
+                                    id
+                                }
                             }
                             createdAt
                             note
@@ -65,12 +68,29 @@
                             transactions (first: 10) {
                                 edges{
                                     node{
+                                        id
+                                        gateway
+                                        processedAt
                                         status
                                         kind
+                                        parentTransaction{
+                                            id
+                                        }
+                                        receiptJson
+                                        paymentDetails {
+                                            ... on CardPaymentDetails {
+                                                paymentMethodName
+                                                company
+                                            }
+                                        }
                                         amountSet{
                                             presentmentMoney{
                                                 amount
                                                 currencyCode
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                     }
@@ -83,6 +103,10 @@
                                             presentmentMoney{
                                                 amount
                                                 currencyCode
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                         id
@@ -110,10 +134,18 @@
                                             presentmentMoney{
                                                 currencyCode
                                                 amount
+                                            },
+                                            shopMoney{
+                                                currencyCode
+                                                amount
                                             }
                                         }
                                         amountSet{
                                             presentmentMoney{
+                                                currencyCode
+                                                amount
+                                            },
+                                            shopMoney{
                                                 currencyCode
                                                 amount
                                             }

--- a/data/UpgradeData_Upcoming.xml
+++ b/data/UpgradeData_Upcoming.xml
@@ -206,4 +206,7 @@
                                                     parameterName="sendSmrId"
                                                     parameterValue=""
                                                     systemMessageRemoteId=""/>
+
+  <ProductCategoryMember fromDate="2024-01-01 00:00:00.0" productCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT"/>
+  <Product description="Create Appeasement from Shopify" internalName="JOB_CRT_APPEASEMENT" isVariant="N" isVirtual="N" primaryProductCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT" productName="Create Appeasement" productTypeId="SERVICE"/>
 </entity-facade-xml>

--- a/data/UpgradeData_v2.3.3.xml
+++ b/data/UpgradeData_v2.3.3.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-facade-xml type="ext-upgrade-v2.3.3">
+  <!-- Product data for polling OMS Fulfilled Items Feed -->
+  <Product productId="POL_OMS_FLFLMNT_FD" productTypeId="SERVICE" internalName="POL_OMS_FLFLMNT_FD"
+           productName="Poll OMS Fulfilled Items Feed" description="Poll OMS Fulfilled Items Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="POL_OMS_FLFLMNT_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data to send Shopify Fulfillment Ack Feed -->
+  <Product productId="SND_SHPFY_FUL_ACK_FD" productTypeId="SERVICE" internalName="SND_SHPFY_FUL_ACK_FD"
+           productName="Send Shopify Fulfillment Ack Feed" description="Send Shopify Fulfillment Ack Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="SND_SHPFY_FUL_ACK_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for sending next bulk query system message in queue-->
+  <Product productId="SND_BLK_SYS_M_SHPFY" productTypeId="SERVICE" internalName="SND_BLK_SYS_M_SHPFY"
+           productName="Send next bulk query system message in queue" description="Send next bulk query system message in queue"
+           primaryProductCategoryId="MISC_SYS_JOB"/>
+  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="UPLOAD_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for polling current bulk operation query result -->
+  <Product productId="POL_BLK_RSLT_SHPFY" productTypeId="SERVICE" internalName="POL_BLK_RSLT_SHPFY"
+           productName="Poll current bulk operation query result" description="Poll current bulk operation query result"
+           primaryProductCategoryId="MISC_SYS_JOB"/>
+  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="IMPORT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for queuing Created productIds feed -->
+  <Product productId="QUEUE_CRT_PRD_IDS_FD" productTypeId="SERVICE" internalName="QUEUE_CRT_PRD_IDS_FD"
+           productName="Queue Created Products Feed" description="Queue Created Products Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+
+  <!-- Product data for queuing Updated productIds feed -->
+  <Product productId="QUEUE_UPD_PRD_FEED" productTypeId="SERVICE" internalName="QUEUE_UPD_PRD_FEED"
+           productName="Queue Product Updates Feed" description="Queue Product Updates Feed"
+           primaryProductCategoryId="PRODUCT_SYS_JOB"/>
+  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+</entity-facade-xml>

--- a/data/UpgradeData_v2.4.0.xml
+++ b/data/UpgradeData_v2.4.0.xml
@@ -248,44 +248,4 @@
 
   <ProductCategoryMember fromDate="2024-01-01 00:00:00.0" productCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT"/>
   <Product description="Create Appeasement from Shopify" internalName="JOB_CRT_APPEASEMENT" isVariant="N" isVirtual="N" primaryProductCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT" productName="Create Appeasement" productTypeId="SERVICE"/>
-
-  <!-- Product data for polling OMS Fulfilled Items Feed -->
-  <Product productId="POL_OMS_FLFLMNT_FD" productTypeId="SERVICE" internalName="POL_OMS_FLFLMNT_FD"
-           productName="Poll OMS Fulfilled Items Feed" description="Poll OMS Fulfilled Items Feed"
-           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
-  <ProductCategoryMember productId="POL_OMS_FLFLMNT_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-
-  <!-- Product data to send Shopify Fulfillment Ack Feed -->
-  <Product productId="SND_SHPFY_FUL_ACK_FD" productTypeId="SERVICE" internalName="SND_SHPFY_FUL_ACK_FD"
-           productName="Send Shopify Fulfillment Ack Feed" description="Send Shopify Fulfillment Ack Feed"
-           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
-  <ProductCategoryMember productId="SND_SHPFY_FUL_ACK_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-
-  <!-- Product data for sending next bulk query system message in queue-->
-  <Product productId="SND_BLK_SYS_M_SHPFY" productTypeId="SERVICE" internalName="SND_BLK_SYS_M_SHPFY"
-           productName="Send next bulk query system message in queue" description="Send next bulk query system message in queue"
-           primaryProductCategoryId="MISC_SYS_JOB"/>
-  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="UPLOAD_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-
-  <!-- Product data for polling current bulk operation query result -->
-  <Product productId="POL_BLK_RSLT_SHPFY" productTypeId="SERVICE" internalName="POL_BLK_RSLT_SHPFY"
-           productName="Poll current bulk operation query result" description="Poll current bulk operation query result"
-           primaryProductCategoryId="MISC_SYS_JOB"/>
-  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="IMPORT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
-
-  <!-- Product data for queuing Created productIds feed -->
-  <Product productId="QUEUE_CRT_PRD_IDS_FD" productTypeId="SERVICE" internalName="QUEUE_CRT_PRD_IDS_FD"
-           productName="Queue Created Products Feed" description="Queue Created Products Feed"
-           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
-  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
-  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
-
-  <!-- Product data for queuing Updated productIds feed -->
-  <Product productId="QUEUE_UPD_PRD_FEED" productTypeId="SERVICE" internalName="QUEUE_UPD_PRD_FEED"
-           productName="Queue Product Updates Feed" description="Queue Product Updates Feed"
-           primaryProductCategoryId="PRODUCT_SYS_JOB"/>
-  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
-  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
 </entity-facade-xml>

--- a/data/UpgradeData_v2.4.0.xml
+++ b/data/UpgradeData_v2.4.0.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<entity-facade-xml type="ext-upgrade-upcoming">
+<entity-facade-xml type="ext-upgrade">
 <!--  Shopify GraphQl Template to request data from shopify -->
   <moqui.resource.DbResource filename="AppeasementIdsQuery.ftl" isFile="Y" resourceId="AppeasementIdsQuery" parentResourceId="GraphQL">
     <file mimeType="text/html" versionName="01" rootVersionName="01">

--- a/data/UpgradeData_v2.4.0.xml
+++ b/data/UpgradeData_v2.4.0.xml
@@ -248,4 +248,44 @@
 
   <ProductCategoryMember fromDate="2024-01-01 00:00:00.0" productCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT"/>
   <Product description="Create Appeasement from Shopify" internalName="JOB_CRT_APPEASEMENT" isVariant="N" isVirtual="N" primaryProductCategoryId="ORDER_SYS_JOB" productId="JOB_CRT_APPEASEMENT" productName="Create Appeasement" productTypeId="SERVICE"/>
+
+  <!-- Product data for polling OMS Fulfilled Items Feed -->
+  <Product productId="POL_OMS_FLFLMNT_FD" productTypeId="SERVICE" internalName="POL_OMS_FLFLMNT_FD"
+           productName="Poll OMS Fulfilled Items Feed" description="Poll OMS Fulfilled Items Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="POL_OMS_FLFLMNT_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data to send Shopify Fulfillment Ack Feed -->
+  <Product productId="SND_SHPFY_FUL_ACK_FD" productTypeId="SERVICE" internalName="SND_SHPFY_FUL_ACK_FD"
+           productName="Send Shopify Fulfillment Ack Feed" description="Send Shopify Fulfillment Ack Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="SND_SHPFY_FUL_ACK_FD" productCategoryId="FULFILLMENT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for sending next bulk query system message in queue-->
+  <Product productId="SND_BLK_SYS_M_SHPFY" productTypeId="SERVICE" internalName="SND_BLK_SYS_M_SHPFY"
+           productName="Send next bulk query system message in queue" description="Send next bulk query system message in queue"
+           primaryProductCategoryId="MISC_SYS_JOB"/>
+  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+  <ProductCategoryMember productId="SND_BLK_SYS_M_SHPFY" productCategoryId="UPLOAD_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for polling current bulk operation query result -->
+  <Product productId="POL_BLK_RSLT_SHPFY" productTypeId="SERVICE" internalName="POL_BLK_RSLT_SHPFY"
+           productName="Poll current bulk operation query result" description="Poll current bulk operation query result"
+           primaryProductCategoryId="MISC_SYS_JOB"/>
+  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="MISC_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+  <ProductCategoryMember productId="POL_BLK_RSLT_SHPFY" productCategoryId="IMPORT_SYS_JOB" fromDate="2025-01-01 00:00:00.0"/>
+
+  <!-- Product data for queuing Created productIds feed -->
+  <Product productId="QUEUE_CRT_PRD_IDS_FD" productTypeId="SERVICE" internalName="QUEUE_CRT_PRD_IDS_FD"
+           productName="Queue Created Products Feed" description="Queue Created Products Feed"
+           primaryProductCategoryId="FULFILLMENT_SYS_JOB"/>
+  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+  <ProductCategoryMember productId="QUEUE_CRT_PRD_IDS_FD" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+
+  <!-- Product data for queuing Updated productIds feed -->
+  <Product productId="QUEUE_UPD_PRD_FEED" productTypeId="SERVICE" internalName="QUEUE_UPD_PRD_FEED"
+           productName="Queue Product Updates Feed" description="Queue Product Updates Feed"
+           primaryProductCategoryId="PRODUCT_SYS_JOB"/>
+  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="PRODUCT_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
+  <ProductCategoryMember productId="QUEUE_UPD_PRD_FEED" productCategoryId="UPLOAD_SYS_JOB" fromDate="2024-01-01 00:00:00"/>
 </entity-facade-xml>

--- a/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
+++ b/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
@@ -349,6 +349,29 @@ under the License.
         </actions>
     </service>
 
+    <service verb="get" noun="AppeasementDetails">
+        <description>Get all returns detail for a given shopify orderId</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="appeasementId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="appeasementResponse"/>
+        </out-parameters>
+        <actions>
+            <set field="appeasementDetails" from="[:]"/>
+            <script>
+                queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")
+            </script>
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>
+            <if condition="appeasementDetailsResponse">
+                <log level="warn" message="get#AppeasementDetails ===================  appeasementDetailsResponse : ${appeasementDetailsResponse}"/>
+                <set field="appeasementDetails" from="appeasementDetailsResponse.response.node"/>
+            </if>
+            <log level="warn" message="get#AppeasementDetails ===================  appeasementDetails : ${AppeasementDetails}"/>
+        </actions>
+    </service>
+
     <service verb="get" noun="ExchangesByOrderId">
         <description>Get all exchanges detail for a given shopify orderId</description>
         <in-parameters>

--- a/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
+++ b/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
@@ -364,13 +364,10 @@ under the License.
                 queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")
             </script>
 
-            <log level="warn" message="get#AppeasementDetails ===================  shopifyRefundId : ${shopifyRefundId}"/>
             <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>
             <if condition="appeasementDetailsResponse.response.node">
-                <log level="warn" message="get#AppeasementDetails ===================  appeasementDetailsResponse : ${appeasementDetailsResponse}"/>
                 <set field="appeasementResponse" from="appeasementDetailsResponse.response.node"/>
             </if>
-            <log level="warn" message="get#AppeasementDetails ===================  appeasementResponse : ${appeasementResponse}"/>
         </actions>
     </service>
 

--- a/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
+++ b/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
@@ -353,22 +353,24 @@ under the License.
         <description>Get all returns detail for a given shopify orderId</description>
         <in-parameters>
             <parameter name="systemMessageRemoteId" required="true"/>
-            <parameter name="appeasementId" required="true"/>
+            <parameter name="shopifyRefundId" required="true"/>
         </in-parameters>
         <out-parameters>
             <parameter name="appeasementResponse"/>
         </out-parameters>
         <actions>
-            <set field="appeasementDetails" from="[:]"/>
+<!--            <set field="appeasementDetails" from="[:]"/>-->
             <script>
                 queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")
             </script>
+
+            <log level="warn" message="get#AppeasementDetails ===================  shopifyRefundId : ${shopifyRefundId}"/>
             <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>
-            <if condition="appeasementDetailsResponse">
+            <if condition="appeasementDetailsResponse.response.node">
                 <log level="warn" message="get#AppeasementDetails ===================  appeasementDetailsResponse : ${appeasementDetailsResponse}"/>
-                <set field="appeasementDetails" from="appeasementDetailsResponse.response.node"/>
+                <set field="appeasementResponse" from="appeasementDetailsResponse.response.node"/>
             </if>
-            <log level="warn" message="get#AppeasementDetails ===================  appeasementDetails : ${AppeasementDetails}"/>
+            <log level="warn" message="get#AppeasementDetails ===================  appeasementResponse : ${appeasementResponse}"/>
         </actions>
     </service>
 

--- a/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
+++ b/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
@@ -142,7 +142,6 @@ under the License.
                     queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundTransactionsByIdQuery.ftl", "")
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundTransactionsResponse"/>
-                <log level="info" message="refundTransactionsResponse: ${refundTransactionsResponse}"/>
                 <if condition="!refundTransactionsResponse.response.node">
                     <return message="No Shopify refund found for id: ${refundId}"/>
                 </if>
@@ -410,71 +409,6 @@ under the License.
             <set field="orderReturns.returns" from="returns"/>
         </actions>
     </service>
-
-<!--    <service verb="get" noun="RefundsByOrderId">-->
-<!--        <description>Get all refunds detail for a given shopify orderId</description>-->
-<!--        <in-parameters>-->
-<!--            <parameter name="systemMessageRemoteId" required="true"/>-->
-<!--            <parameter name="shopifyOrderId" required="true"/>-->
-<!--        </in-parameters>-->
-<!--        <out-parameters>-->
-<!--            <parameter name="orderRefunds"/>-->
-<!--        </out-parameters>-->
-<!--        <actions>-->
-<!--            <set field="orderRefunds" from="[:]"/>-->
-<!--            <set field="hasNextPage" type="Boolean" value="true"/>-->
-<!--            <set field="refunds" from="[]"/>-->
-<!--            <while condition="hasNextPage">-->
-<!--                <script>-->
-<!--                    queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByOrderIDQuery.ftl", "")-->
-<!--                </script>-->
-<!--                <log level="warn" message="SHOPIFY SERVICE CALLED =========================== shopifyOrderId: ${shopifyOrderId}"/>-->
-<!--                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundResponse"/>-->
-<!--                <log level="warn" message="SHOPIFY SERVICE CALLED =========================== refundResponse: ${refundResponse}"/>-->
-<!--                <if condition="!refundResponse.response.node">-->
-<!--                    <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>-->
-<!--                </if>-->
-<!--                &lt;!&ndash; Getting all the refundIds for the shopifyOrderId&ndash;&gt;-->
-<!--                <set field="refundIdList" from="[]"/>-->
-<!--                <if condition="refundResponse.response.node.refunds">-->
-<!--                    <script>refundIdList.addAll(refundResponse.response.node.refunds.id)</script>-->
-<!--                </if>-->
-<!--                &lt;!&ndash; Getting refund details for each refundId&ndash;&gt;-->
-<!--                <iterate list="refundIdList" entry="refundId">-->
-<!--                    <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, refundId:refundId]" out-map="refundDetails"/>-->
-<!--                    <log level="warn" message="SHOPIFY SERVICE CALLED =========================== refundDetails: ${refundDetails}"/>-->
-<!--                    <script>refunds.addAll(refundDetails.refundDetail)</script>-->
-<!--                </iterate>-->
-<!--                <set field="hasNextPage" from="refundResponse.response.node.refunds.pageInfo.hasNextPage"/>-->
-<!--                <set field="cursor" from="refundResponse.response.node.refunds.pageInfo.endCursor"/>-->
-<!--            </while>-->
-<!--            <set field="orderRefunds.id" from="refundResponse.response.node.id"/>-->
-<!--            <set field="orderRefunds.name" from="refundResponse.response.node.name"/>-->
-<!--            <set field="orderRefunds.refunds" from="refunds"/>-->
-<!--        </actions>-->
-<!--    </service>-->
-
-<!--    <service verb="get" noun="AppeasementDetails">-->
-<!--        <description>Get all returns detail for a given shopify orderId</description>-->
-<!--        <in-parameters>-->
-<!--            <parameter name="systemMessageRemoteId" required="true"/>-->
-<!--            <parameter name="shopifyRefundId" required="true"/>-->
-<!--        </in-parameters>-->
-<!--        <out-parameters>-->
-<!--            <parameter name="appeasementResponse"/>-->
-<!--        </out-parameters>-->
-<!--        <actions>-->
-<!--&lt;!&ndash;            <set field="appeasementDetails" from="[:]"/>&ndash;&gt;-->
-<!--            <script>-->
-<!--                queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")-->
-<!--            </script>-->
-
-<!--            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>-->
-<!--            <if condition="appeasementDetailsResponse.response.node">-->
-<!--                <set field="appeasementResponse" from="appeasementDetailsResponse.response.node"/>-->
-<!--            </if>-->
-<!--        </actions>-->
-<!--    </service>-->
 
     <service verb="get" noun="ExchangesByOrderId">
         <description>Get all exchanges detail for a given shopify orderId</description>

--- a/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
+++ b/service/co/hotwax/shopify/return/ShopifyReturnServices.xml
@@ -35,13 +35,42 @@ under the License.
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundLineItemsResponse"/>
                 <if condition="!refundLineItemsResponse.response.node">
-                    <return message="No Shopify refund found for id: ${refundId}"/>
+                    <return message="No Shopify refund found for id: ${shopifyRefundId}"/>
                 </if>
                 <if condition="refundLineItemsResponse.response.node.refundLineItems.edges">
                     <script>refundLineItems.addAll(refundLineItemsResponse.response.node.refundLineItems.edges.node)</script>
                 </if>
                 <set field="hasNextPage" from="refundLineItemsResponse.response.node.refundLineItems.pageInfo.hasNextPage"/>
                 <set field="cursor" from="refundLineItemsResponse.response.node.refundLineItems.pageInfo.endCursor"/>
+            </while>
+        </actions>
+    </service>
+
+    <service verb="get" noun="RefundShippingLines" authenticate="anonymous-all">
+        <description>Integrates with Shopify GraphQL Refund API to get associated refund shipping lines.</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="shopifyRefundId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="refundShippingLines"/>
+        </out-parameters>
+        <actions>
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <set field="refundShippingLines" from="[]"/>
+            <while condition="hasNextPage">
+                <script>
+                    queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundShippingLinesByIdQuery.ftl", "")
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundShippingLinesResponse"/>
+                <if condition="!refundShippingLinesResponse.response.node">
+                    <return message="No Shopify refund found for id: ${shopifyRefundId}"/>
+                </if>
+                <if condition="refundShippingLinesResponse.response.node.refundShippingLines.edges">
+                    <script>refundShippingLines.addAll(refundShippingLinesResponse.response.node.refundShippingLines.edges.node)</script>
+                </if>
+                <set field="hasNextPage" from="refundShippingLinesResponse.response.node.refundShippingLines.pageInfo.hasNextPage"/>
+                <set field="cursor" from="refundShippingLinesResponse.response.node.refundShippingLines.pageInfo.endCursor"/>
             </while>
         </actions>
     </service>
@@ -309,6 +338,39 @@ under the License.
         </actions>
     </service>
 
+    <service verb="get" noun="RefundDetails">
+        <description>Get refund details for a given Return Id</description>
+        <in-parameters>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="refundId" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="refundDetail"/>
+        </out-parameters>
+        <actions>
+            <script>
+                queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundHeaderByIdQuery.ftl", "")
+            </script>
+            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundResponse"/>
+            <if condition="!refundResponse.response.node">
+                <return type="warning" message="No Shopify refund found for id: ${refundId}"/>
+            </if>
+            <set field="refundDetail" from="refundResponse.response.node"/>
+
+            <!-- Getting refund Line Items for refundId-->
+            <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundLineItems" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyRefundId:refundId]" out-map="refundLineItemsResponse"/>
+            <set field="refundDetail.refundLineItems" from="refundLineItemsResponse.refundLineItems"/>
+
+            <!-- Getting transactions for refundId-->
+            <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundTransactions" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyRefundId:refundId]" out-map="refundTransactionsResponse"/>
+            <set field="refundDetail.transactions" from="refundTransactionsResponse.refundTransactions"/>
+
+            <!-- Getting refund shipping Lines for refundId-->
+            <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundShippingLines" in-map="[systemMessageRemoteId:systemMessageRemoteId, shopifyRefundId:refundId]" out-map="refundShippingLinesResponse"/>
+            <set field="refundDetail.refundShippingLines" from="refundShippingLinesResponse.refundShippingLines"/>
+        </actions>
+    </service>
+
     <service verb="get" noun="ReturnsByOrderId">
         <description>Get all returns detail for a given shopify orderId</description>
         <in-parameters>
@@ -349,27 +411,70 @@ under the License.
         </actions>
     </service>
 
-    <service verb="get" noun="AppeasementDetails">
-        <description>Get all returns detail for a given shopify orderId</description>
-        <in-parameters>
-            <parameter name="systemMessageRemoteId" required="true"/>
-            <parameter name="shopifyRefundId" required="true"/>
-        </in-parameters>
-        <out-parameters>
-            <parameter name="appeasementResponse"/>
-        </out-parameters>
-        <actions>
-<!--            <set field="appeasementDetails" from="[:]"/>-->
-            <script>
-                queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")
-            </script>
+<!--    <service verb="get" noun="RefundsByOrderId">-->
+<!--        <description>Get all refunds detail for a given shopify orderId</description>-->
+<!--        <in-parameters>-->
+<!--            <parameter name="systemMessageRemoteId" required="true"/>-->
+<!--            <parameter name="shopifyOrderId" required="true"/>-->
+<!--        </in-parameters>-->
+<!--        <out-parameters>-->
+<!--            <parameter name="orderRefunds"/>-->
+<!--        </out-parameters>-->
+<!--        <actions>-->
+<!--            <set field="orderRefunds" from="[:]"/>-->
+<!--            <set field="hasNextPage" type="Boolean" value="true"/>-->
+<!--            <set field="refunds" from="[]"/>-->
+<!--            <while condition="hasNextPage">-->
+<!--                <script>-->
+<!--                    queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByOrderIDQuery.ftl", "")-->
+<!--                </script>-->
+<!--                <log level="warn" message="SHOPIFY SERVICE CALLED =========================== shopifyOrderId: ${shopifyOrderId}"/>-->
+<!--                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="refundResponse"/>-->
+<!--                <log level="warn" message="SHOPIFY SERVICE CALLED =========================== refundResponse: ${refundResponse}"/>-->
+<!--                <if condition="!refundResponse.response.node">-->
+<!--                    <return type="warning" message="No Shopify order found for id: ${shopifyOrderId}"/>-->
+<!--                </if>-->
+<!--                &lt;!&ndash; Getting all the refundIds for the shopifyOrderId&ndash;&gt;-->
+<!--                <set field="refundIdList" from="[]"/>-->
+<!--                <if condition="refundResponse.response.node.refunds">-->
+<!--                    <script>refundIdList.addAll(refundResponse.response.node.refunds.id)</script>-->
+<!--                </if>-->
+<!--                &lt;!&ndash; Getting refund details for each refundId&ndash;&gt;-->
+<!--                <iterate list="refundIdList" entry="refundId">-->
+<!--                    <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundDetails" in-map="[systemMessageRemoteId:systemMessageRemoteId, refundId:refundId]" out-map="refundDetails"/>-->
+<!--                    <log level="warn" message="SHOPIFY SERVICE CALLED =========================== refundDetails: ${refundDetails}"/>-->
+<!--                    <script>refunds.addAll(refundDetails.refundDetail)</script>-->
+<!--                </iterate>-->
+<!--                <set field="hasNextPage" from="refundResponse.response.node.refunds.pageInfo.hasNextPage"/>-->
+<!--                <set field="cursor" from="refundResponse.response.node.refunds.pageInfo.endCursor"/>-->
+<!--            </while>-->
+<!--            <set field="orderRefunds.id" from="refundResponse.response.node.id"/>-->
+<!--            <set field="orderRefunds.name" from="refundResponse.response.node.name"/>-->
+<!--            <set field="orderRefunds.refunds" from="refunds"/>-->
+<!--        </actions>-->
+<!--    </service>-->
 
-            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>
-            <if condition="appeasementDetailsResponse.response.node">
-                <set field="appeasementResponse" from="appeasementDetailsResponse.response.node"/>
-            </if>
-        </actions>
-    </service>
+<!--    <service verb="get" noun="AppeasementDetails">-->
+<!--        <description>Get all returns detail for a given shopify orderId</description>-->
+<!--        <in-parameters>-->
+<!--            <parameter name="systemMessageRemoteId" required="true"/>-->
+<!--            <parameter name="shopifyRefundId" required="true"/>-->
+<!--        </in-parameters>-->
+<!--        <out-parameters>-->
+<!--            <parameter name="appeasementResponse"/>-->
+<!--        </out-parameters>-->
+<!--        <actions>-->
+<!--&lt;!&ndash;            <set field="appeasementDetails" from="[:]"/>&ndash;&gt;-->
+<!--            <script>-->
+<!--                queryText = ec.resourceFacade.template("dbresource://shopify/template/graphQL/RefundsByIDQuery.ftl", "")-->
+<!--            </script>-->
+
+<!--            <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessageRemoteId, queryText:queryText]" out-map="appeasementDetailsResponse"/>-->
+<!--            <if condition="appeasementDetailsResponse.response.node">-->
+<!--                <set field="appeasementResponse" from="appeasementDetailsResponse.response.node"/>-->
+<!--            </if>-->
+<!--        </actions>-->
+<!--    </service>-->
 
     <service verb="get" noun="ExchangesByOrderId">
         <description>Get all exchanges detail for a given shopify orderId</description>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -705,27 +705,76 @@ under the License.
                 <set field="thruZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(thruDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
                 <set field="queryParams.thruDate" from="thruZdtUTC.toString()"/>
             </if>
+            <log level="warn" message="SERVICE CALL STARTED FOR SYSTEM MESSAGE QUEUE [systemMessageTypeId:${systemMessageTypeId}, systemMessageRemoteId:${systemMessageRemoteId},
+                                       messageText:${org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams)},  sendNow:true]"/>
+
             <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                           in-map="[systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId,
                                        messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams),  sendNow:true]"
                           out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
+            <log level="warn" message="SERVICE CALL ENDED FOR SYSTEM MESSAGE QUEUE"/>
         </actions>
     </service>
+
+    <service verb="queue" noun="AppeasementIdsFeed" authenticate="anonymous-all">
+        <in-parameters>
+            <parameter name="systemMessageTypeId" required="true"/>
+            <parameter name="systemMessageRemoteId" required="true"/>
+            <parameter name="fromDate"/>
+            <parameter name="thruDate"/>
+        </in-parameters>
+        <actions>
+            <set field="queryParams" from="[:]"/>
+            <log level="warn" message="SERVICE queue#AppeasementIdsFeed, queryParams ============================ ${queryParams}"/>
+            <if condition="!fromDate">
+                <entity-find entity-name="moqui.service.message.SystemMessage" list="SystemMessageList" limit="1">
+                    <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId"/>
+                    <econdition field-name="statusId" operator="equals" value="SmsgSent"/>
+                    <order-by field-name="-processedDate"/>
+                </entity-find>
+                <if condition="systemMessageList">
+                    <set field="fromDate" from="systemMessageList[0].processedDate" type="String"/>
+                </if>
+            </if>
+            <log level="warn" message="SERVICE queue#AppeasementIdsFeed,  fromDate============================ ${fromDate}"/>
+            <if condition="fromDate">
+                <set field="fromZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(fromDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
+                <set field="queryParams.fromDate" from="fromZdtUTC.toString()"/>
+            </if>
+            <log level="warn" message="SERVICE queue#AppeasementIdsFeed, thruDate ============================ ${thruDate}"/>
+            <if condition="thruDate">
+                <set field="thruZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(thruDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
+                <set field="queryParams.thruDate" from="thruZdtUTC.toString()"/>
+            </if>
+
+            <log level="warn" message="SERVICE called queue#AppeasementIdsFeed  ============================ ${systemMessageRemoteId}, ${systemMessageTypeId}"/>
+            <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
+                          in-map="[systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, sendNow:true, messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams)]"
+                          out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
+            <log level="warn" message="SERVICE result queue#AppeasementIdsFeed ============================ ${queueSystemMessageOut}"/>
+        </actions>
+    </service>
+
     <service verb="generate" noun="ReturnedOrderIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
         <description>Generate returned orderIds feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
         <actions>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE started =================== systemMessageId : ${systemMessageId}"/>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== moqui.service.message.SystemMessageAndType : ${systemMessage}"/>
 
             <!-- Find SystemMessageType related to systemMessage.systemMessageType to produce corresponding system message -->
             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumValue">
                 <field-map field-name="enumId" from="systemMessage.systemMessageTypeId"/>
             </entity-find-one>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== Enum : ${enumValue}"/>
 
             <if condition="enumValue &amp;&amp; enumValue.relatedEnumId">
                 <entity-find-one entity-name="moqui.service.message.SystemMessageType" value-field="relatedSystemMessageType">
                     <field-map field-name="systemMessageTypeId" from="enumValue.relatedEnumId"/>
                 </entity-find-one>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== relatedSystemMessageType : ${relatedSystemMessageType}"/>
+
                 <if condition="!relatedSystemMessageType"><log level="warn" message="Could not find SystemMessageType with ID ${enumValue.relatedEnumId}, not producing related system message."/></if>
                 <else>
                     <log level="warn" message="Related SystemMessageType to produce for ${systemMessage.systemMessageTypeId} not defined, not producing related system message."/>
@@ -733,6 +782,7 @@ under the License.
             </if>
 
             <set field="queryParams" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== queryParams : ${queryParams}"/>
 
             <script>
                 import com.fasterxml.jackson.core.JsonGenerator
@@ -741,18 +791,22 @@ under the License.
                 import java.nio.charset.StandardCharsets
             </script>
             <set field="hasNextPage" type="Boolean" value="true"/>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== loop started : ${hasNextPage}"/>
             <while condition="hasNextPage">
                 <script>
                     queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
                 </script>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== ShopifyGraphqlRequest"/>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="returnedOrderIdsResponse"/>
                 <if condition="!returnedOrderIdsResponse.response.orders.edges">
                     <return message="No returned orderIds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
                 </if>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== ShopifyGraphqlRequest: ${returnedOrderIdsResponse}"/>
                 <set field="nowDate" from="ec.user.nowTimestamp"/>
                 <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null,
                     [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
                 <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
                 <script>
                     try {
                     //json file
@@ -767,6 +821,7 @@ under the License.
                         jGenerator.writeStartArray()
                 </script>
                 <set field="returnedOrderIds" from="returnedOrderIdsResponse.response.orders.edges"/>
+            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== returnedOrderIds: ${returnedOrderIds}"/>
                 <iterate list="returnedOrderIds" entry="returnedOrderIdMap">
                     <script>
                         new ObjectMapper()
@@ -782,14 +837,206 @@ under the License.
                     }
                 </script>
                 <if condition="relatedSystemMessageType">
+                    <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
                     <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
+                    <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== serve call IncomingSystemMessage"/>
                 </if>
                 <set field="hasNextPage" from="returnedOrderIdsResponse.response.orders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="returnedOrderIdsResponse.response.orders.pageInfo.endCursor"/>
             </while>
         </actions>
     </service>
+
+    <service verb="generate" noun="AppeasementIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
+        <description>Generate returned orderIds feed.</description>
+        <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
+        <actions>
+            <log level="warn" message="generate#AppeasementIdsFeed ==================== Service started"/>
+            <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
+            <log level="warn" message="generate#AppeasementIdsFeed ==================== systemMessage : ${systemMessage}"/>
+
+            <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumValue">
+                <field-map field-name="enumId" from="systemMessage.systemMessageTypeId"/>
+            </entity-find-one>
+
+            <if condition="enumValue &amp;&amp; enumValue.relatedEnumId">
+                <entity-find-one entity-name="moqui.service.message.SystemMessageType" value-field="relatedSystemMessageType">
+                    <field-map field-name="systemMessageTypeId" from="enumValue.relatedEnumId"/>
+                </entity-find-one>
+                <if condition="!relatedSystemMessageType"><log level="warn" message="Could not find SystemMessageType with ID ${enumValue.relatedEnumId}, not producing related system message."/></if>
+                <else>
+                    <log level="warn" message="Related SystemMessageType to produce for ${systemMessage.systemMessageTypeId} not defined, not producing related system message."/>
+                </else>
+            </if>
+            <set field="queryParams" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
+            <script>
+                import com.fasterxml.jackson.core.JsonGenerator
+                import com.fasterxml.jackson.core.JsonFactory
+                import com.fasterxml.jackson.databind.ObjectMapper
+                import java.nio.charset.StandardCharsets
+            </script>
+            <set field="hasNextPage" type="Boolean" value="true"/>
+            <log level="warn" message="generate#AppeasementIdsFeed ==================== loop started ,queryParams: ${queryParams}"/>
+
+            <while condition="hasNextPage">
+                <script>
+                    queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
+                </script>
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="appeasementIdsResponse"/>
+                <log level="warn" message="GENERATE APPEASEMENT SERVICE =================== ShopifyGraphqlRequest: ${appeasementIdsResponse}"/>
+                <if condition="!appeasementIdsResponse.response.orders.edges">
+                    <return message="No Order with refunds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
+                </if>
+                <set field="nowDate" from="ec.user.nowTimestamp"/>
+                <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null, [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
+                <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+                <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
+                <script>
+                    try{
+                    File feedFile = new File(jsonFilePath)
+                    if (!feedFile.parentFile.exists()) feedFile.parentFile.mkdirs()
+                    JsonFactory jfactory = new JsonFactory()
+                    try (PrintWriter pw = new PrintWriter(StandardCharsets.UTF_8, feedFile);
+                    JsonGenerator jGenerator = jfactory.createGenerator(pw)){
+                        jGenerator.writeStartArray()
+                </script>
+                <set field="appeasementIds" from="[]"/>
+<!--                <iterate list="appeasementIdsResponse.response.orders.edges.node" entry="order">-->
+<!--                    <script>appeasementIds.addAll(order.refunds.id)</script>-->
+<!--                </iterate>-->
+
+                <set field="appeasementOrderIds" from="appeasementIdsResponse.response.orders.edges"/>
+                <iterate list="appeasementOrderIds" entry="appeasementOrderMap">
+                    <iterate list="appeasementOrderMap.node.refunds" entry="refund">
+                        <script>
+                            new ObjectMapper()
+                            .setDateFormat(new java.text.SimpleDateFormat(System.getProperty("default_date_time_format")))
+                            .writerWithDefaultPrettyPrinter().writeValue(jGenerator, refund)
+                        </script>
+                    </iterate>
+                </iterate>
+                <script>
+                            jGenerator.writeEndArray()
+                        }
+                    } catch (IOException e) {
+                        logger.error("Error preparing Order Metafields Feed file", e)
+                    }
+                </script>
+                <log level="warn" message="appeasementOrderIds ==================== ${appeasementOrderIds}"/>
+                <if condition="relatedSystemMessageType">
+                    <log level="warn" message="GENERATE Appeasement ORDER SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
+                    <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
+                              systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
+                    <log level="warn" message="GENERATE Appeasement ORDER SERVICE =================== serve call IncomingSystemMessage"/>
+                </if>
+                <set field="hasNextPage" from="appeasementIdsResponse.response.orders.pageInfo.hasNextPage"/>
+                <set field="cursor" from="appeasementIdsResponse.response.orders.pageInfo.endCursor"/>
+            </while>
+
+        </actions>
+    </service>
+
+    <service verb="generate" noun="AppeasementsFeed" authenticate="anonymous-all" transaction="force-new">
+        <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+        <actions>
+            <log level="info" message="SUCCESSFULLY REACHED generate#AppeasementsFeed======================================"/>
+            <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
+
+            <entity-find-one entity-name="moqui.service.message.SystemMessageTypeParameter" value-field="sendSmrParam">
+                <field-map field-name="systemMessageTypeId" from="systemMessage.systemMessageTypeId"/>
+                <field-map field-name="parameterName" value="sendSmrId"/>
+                <field-map field-name="systemMessageRemoteId" from="systemMessage.systemMessageRemoteId"/>
+            </entity-find-one>
+            <if condition="sendSmrParam">
+                <set field="sendSmrId" from="sendSmrParam.parameterValue"/>
+            </if>
+
+            <if condition="sendSmrId">
+                <!-- Find SystemMessageType related to systemMessage.systemMessageType to produce corresponding system message -->
+                <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumValue">
+                    <field-map field-name="enumId" from="systemMessage.systemMessageTypeId"/>
+                </entity-find-one>
+
+                <if condition="enumValue &amp;&amp; enumValue.relatedEnumId">
+                    <entity-find-one entity-name="moqui.service.message.SystemMessageType" value-field="relatedSystemMessageType">
+                        <field-map field-name="systemMessageTypeId" from="enumValue.relatedEnumId"/>
+                    </entity-find-one>
+                    <if condition="!relatedSystemMessageType"><log level="warn" message="Could not find SystemMessageType with ID ${enumValue.relatedEnumId}, not producing related system message."/></if>
+                    <else>
+                        <log level="warn" message="Related SystemMessageType to produce for ${systemMessage.systemMessageTypeId} not defined, not producing related system message."/>
+                    </else>
+                </if>
+                <else>
+                    <log level="warn" message="sendSmrId not defined for ${systemMessage.systemMessageTypeId} not defined, not producing related system message."/>
+                </else>
+            </if>
+
+            <set field="fileText" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
+            <set field="appeasementIds" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(fileText, List.class)"/>
+
+            <if condition="!appeasementIds">
+                <return type="warning" message="System message [${systemMessageId}] for Type [${systemMessage?.systemMessageTypeId}] has messageText [${systemMessage.messageText}], with AppeasementIdsFeed file having incorrect data and may contain null, not generating appeasements feed file."/>
+            </if>
+
+            <set field="nowDate" from="ec.user.nowTimestamp"/>
+            <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.sendPath, null,
+                    [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', date:ec.l10n.format(nowDate, 'yyyy-MM-dd'),
+                    dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
+            <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
+            <log message="jsonFilePath: ${jsonFilePath}"/>
+            <script>
+                import com.fasterxml.jackson.core.JsonGenerator
+                import com.fasterxml.jackson.core.JsonFactory
+                import com.fasterxml.jackson.databind.ObjectMapper
+                import java.nio.charset.StandardCharsets
+
+                try {
+                //json file
+                ec.logger.info("jsonFilePath:" +jsonFilePath)
+                File feedFile = new File(jsonFilePath)
+                if (!feedFile.parentFile.exists()) feedFile.parentFile.mkdirs()
+                JsonFactory jfactory = new JsonFactory()
+
+                /* Declaring the PrintWriter and JsonGenerator resources in the try statement,
+                so that they are automatically closed regardless of whether the try statement completes normally or abruptly. */
+                try (PrintWriter pw = new PrintWriter(StandardCharsets.UTF_8, feedFile);
+                JsonGenerator jGenerator = jfactory.createGenerator(pw)) {
+                jGenerator.writeStartArray()
+            </script>
+            
+            <iterate list="appeasementIds" entry="appeasementId">
+                <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#AppeasementDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, appeasementId:appeasementId]"
+                              out-map="appeasementResponse" ignore-error="true" transaction="force-new"/>
+                <if condition="appeasementResponse">
+                    <log level="warn" message="generate#appeasementsFeed,============= appeasementResponse ${appeasementResponse}"/>
+                    <set field="appeasementMap" from="appeasementResponse"/>
+                    <script>
+                        new ObjectMapper()
+                        .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
+                        .writerWithDefaultPrettyPrinter().writeValue(jGenerator, appeasementResponse)
+                    </script>
+                </if>
+            </iterate>
+            <script>
+                        jGenerator.writeEndArray()
+                    }
+                } catch (IOException e) {
+                    logger.error("Error preparing Appeasements Feed file", e)
+                }
+            </script>
+
+            <if condition="relatedSystemMessageType">
+                <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
+                              in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, systemMessageRemoteId:sendSmrId,
+                                       messageText:jsonFilePathRef, remoteMessageId: jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
+                              out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
+            </if>
+
+            <log level="error" message="FINAL CALL ================= queueSystemMessageOut: ${queueSystemMessageOut}"/>
+        </actions>
+    </service>
+
     <service verb="generate" noun="ReturnsAndExchangeFeed" authenticate="anonymous-all" transaction-timeout="1800">
         <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
         <actions>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -725,7 +725,6 @@ under the License.
         </in-parameters>
         <actions>
             <set field="queryParams" from="[:]"/>
-            <log level="warn" message="SERVICE queue#AppeasementIdsFeed, queryParams ============================ ${queryParams}"/>
             <if condition="!fromDate">
                 <entity-find entity-name="moqui.service.message.SystemMessage" list="SystemMessageList" limit="1">
                     <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId"/>
@@ -736,22 +735,18 @@ under the License.
                     <set field="fromDate" from="systemMessageList[0].processedDate" type="String"/>
                 </if>
             </if>
-            <log level="warn" message="SERVICE queue#AppeasementIdsFeed,  fromDate============================ ${fromDate}"/>
             <if condition="fromDate">
                 <set field="fromZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(fromDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
                 <set field="queryParams.fromDate" from="fromZdtUTC.toString()"/>
             </if>
-            <log level="warn" message="SERVICE queue#AppeasementIdsFeed, thruDate ============================ ${thruDate}"/>
             <if condition="thruDate">
                 <set field="thruZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(thruDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
                 <set field="queryParams.thruDate" from="thruZdtUTC.toString()"/>
             </if>
 
-            <log level="warn" message="SERVICE called queue#AppeasementIdsFeed  ============================ ${systemMessageRemoteId}, ${systemMessageTypeId}"/>
             <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                           in-map="[systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, sendNow:true, messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams)]"
                           out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
-            <log level="warn" message="SERVICE result queue#AppeasementIdsFeed ============================ ${queueSystemMessageOut}"/>
         </actions>
     </service>
 
@@ -759,21 +754,17 @@ under the License.
         <description>Generate returned orderIds feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
         <actions>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE started =================== systemMessageId : ${systemMessageId}"/>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== moqui.service.message.SystemMessageAndType : ${systemMessage}"/>
 
             <!-- Find SystemMessageType related to systemMessage.systemMessageType to produce corresponding system message -->
             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumValue">
                 <field-map field-name="enumId" from="systemMessage.systemMessageTypeId"/>
             </entity-find-one>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== Enum : ${enumValue}"/>
 
             <if condition="enumValue &amp;&amp; enumValue.relatedEnumId">
                 <entity-find-one entity-name="moqui.service.message.SystemMessageType" value-field="relatedSystemMessageType">
                     <field-map field-name="systemMessageTypeId" from="enumValue.relatedEnumId"/>
                 </entity-find-one>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== relatedSystemMessageType : ${relatedSystemMessageType}"/>
 
                 <if condition="!relatedSystemMessageType"><log level="warn" message="Could not find SystemMessageType with ID ${enumValue.relatedEnumId}, not producing related system message."/></if>
                 <else>
@@ -782,7 +773,6 @@ under the License.
             </if>
 
             <set field="queryParams" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(systemMessage.messageText, Map.class)"/>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== queryParams : ${queryParams}"/>
 
             <script>
                 import com.fasterxml.jackson.core.JsonGenerator
@@ -791,22 +781,18 @@ under the License.
                 import java.nio.charset.StandardCharsets
             </script>
             <set field="hasNextPage" type="Boolean" value="true"/>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== loop started : ${hasNextPage}"/>
             <while condition="hasNextPage">
                 <script>
                     queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
                 </script>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== ShopifyGraphqlRequest"/>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="returnedOrderIdsResponse"/>
                 <if condition="!returnedOrderIdsResponse.response.orders.edges">
                     <return message="No returned orderIds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
                 </if>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== ShopifyGraphqlRequest: ${returnedOrderIdsResponse}"/>
                 <set field="nowDate" from="ec.user.nowTimestamp"/>
                 <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null,
                     [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
                 <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
                 <script>
                     try {
                     //json file
@@ -821,7 +807,6 @@ under the License.
                         jGenerator.writeStartArray()
                 </script>
                 <set field="returnedOrderIds" from="returnedOrderIdsResponse.response.orders.edges"/>
-            <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== returnedOrderIds: ${returnedOrderIds}"/>
                 <iterate list="returnedOrderIds" entry="returnedOrderIdMap">
                     <script>
                         new ObjectMapper()
@@ -837,10 +822,8 @@ under the License.
                     }
                 </script>
                 <if condition="relatedSystemMessageType">
-                    <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
                     <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
-                    <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== serve call IncomingSystemMessage"/>
                 </if>
                 <set field="hasNextPage" from="returnedOrderIdsResponse.response.orders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="returnedOrderIdsResponse.response.orders.pageInfo.endCursor"/>
@@ -852,9 +835,7 @@ under the License.
         <description>Generate returned orderIds feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
         <actions>
-            <log level="warn" message="generate#AppeasementIdsFeed ==================== Service started"/>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
-            <log level="warn" message="generate#AppeasementIdsFeed ==================== systemMessage : ${systemMessage}"/>
 
             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="enumValue">
                 <field-map field-name="enumId" from="systemMessage.systemMessageTypeId"/>
@@ -877,21 +858,18 @@ under the License.
                 import java.nio.charset.StandardCharsets
             </script>
             <set field="hasNextPage" type="Boolean" value="true"/>
-            <log level="warn" message="generate#AppeasementIdsFeed ==================== loop started ,queryParams: ${queryParams}"/>
 
             <while condition="hasNextPage">
                 <script>
                     queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="appeasementIdsResponse"/>
-                <log level="warn" message="GENERATE APPEASEMENT IDs SERVICE =================== ShopifyGraphqlRequest: ${appeasementIdsResponse}"/>
                 <if condition="!appeasementIdsResponse.response.orders.edges">
                     <return message="No Order with refunds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
                 </if>
                 <set field="nowDate" from="ec.user.nowTimestamp"/>
                 <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null, [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
                 <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
-                <log level="warn" message="GENERATE APPEASEMENT IDs SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
                 <script>
                     try{
                     File feedFile = new File(jsonFilePath)
@@ -902,11 +880,6 @@ under the License.
                         jGenerator.writeStartArray()
                 </script>
                 <set field="appeasementIds" from="[]"/>
-<!--                <iterate list="appeasementIdsResponse.response.orders.edges.node" entry="order">-->
-<!--                    <script>appeasementIds.addAll(order.refunds.id)</script>-->
-<!--                </iterate>-->
-
-                <log level="warn" message="appeasementIdsResponse.response.orders.edges=============================== ${appeasementIdsResponse.response.orders.edges}"/>
                 <set field="appeasementOrderIds" from="appeasementIdsResponse.response.orders.edges"/>
                 <iterate list="appeasementOrderIds" entry="appeasementOrderMap">
                     <iterate list="appeasementOrderMap.node.refunds" entry="refund">
@@ -924,12 +897,9 @@ under the License.
                         logger.error("Error preparing Order Metafields Feed file", e)
                     }
                 </script>
-                <log level="warn" message="appeasementOrderIds ==================== ${appeasementOrderIds}"/>
                 <if condition="relatedSystemMessageType">
-                    <log level="warn" message="GENERATE Appeasement Ids SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
                     <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
-                    <log level="warn" message="GENERATE Appeasement Ids SERVICE =================== serve call IncomingSystemMessage"/>
                 </if>
                 <set field="hasNextPage" from="appeasementIdsResponse.response.orders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="appeasementIdsResponse.response.orders.pageInfo.endCursor"/>
@@ -938,10 +908,9 @@ under the License.
         </actions>
     </service>
 
-    <service verb="generate" noun="AppeasementsFeed" authenticate="anonymous-all" transaction="force-new">
+    <service verb="generate" noun="AppeasementsFeed" authenticate="anonymous-all" transaction-timeout="1800">
         <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
         <actions>
-            <log level="info" message="SUCCESSFULLY REACHED generate#AppeasementsFeed======================================"/>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
 
             <entity-find-one entity-name="moqui.service.message.SystemMessageTypeParameter" value-field="sendSmrParam">
@@ -1009,7 +978,6 @@ under the License.
             <iterate list="appeasementIds" entry="appeasementId">
                 <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#AppeasementDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyRefundId:appeasementId.id]"
                               out-map="appeasementResponse" ignore-error="true" transaction="force-new"/>
-                <log level="warn" message="generate#appeasementsFeed,============= appeasementResponse ${appeasementResponse}"/>
                 <if condition="appeasementResponse">
                     <set field="appeasementMap" from="appeasementResponse.appeasementResponse"/>
                     <script>
@@ -1028,15 +996,12 @@ under the License.
             </script>
 
             <if condition="relatedSystemMessageType">
-                <log level="warn" message="FINAL CALL ================= org.moqui.impl.SystemMessageServices.queue#SystemMessage======= \nsystemMessageTypeId:${relatedSystemMessageType.systemMessageTypeId}, systemMessageRemoteId:\n ${sendSmrId},
-                                       \n messageText:${jsonFilePathRef}, \n remoteMessageId: ${jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)}"/>
                 <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                               in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, systemMessageRemoteId:sendSmrId,
                                        messageText:jsonFilePathRef, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
                               out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
             </if>
 
-            <log level="error" message="FINAL CALL RESP================= queueSystemMessageOut: ${queueSystemMessageOut}"/>
         </actions>
     </service>
 

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -716,40 +716,6 @@ under the License.
         </actions>
     </service>
 
-    <service verb="queue" noun="AppeasementIdsFeed" authenticate="anonymous-all">
-        <in-parameters>
-            <parameter name="systemMessageTypeId" required="true"/>
-            <parameter name="systemMessageRemoteId" required="true"/>
-            <parameter name="fromDate"/>
-            <parameter name="thruDate"/>
-        </in-parameters>
-        <actions>
-            <set field="queryParams" from="[:]"/>
-            <if condition="!fromDate">
-                <entity-find entity-name="moqui.service.message.SystemMessage" list="SystemMessageList" limit="1">
-                    <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId"/>
-                    <econdition field-name="statusId" operator="equals" value="SmsgSent"/>
-                    <order-by field-name="-processedDate"/>
-                </entity-find>
-                <if condition="systemMessageList">
-                    <set field="fromDate" from="systemMessageList[0].processedDate" type="String"/>
-                </if>
-            </if>
-            <if condition="fromDate">
-                <set field="fromZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(fromDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
-                <set field="queryParams.fromDate" from="fromZdtUTC.toString()"/>
-            </if>
-            <if condition="thruDate">
-                <set field="thruZdtUTC" from="java.time.ZonedDateTime.ofInstant(Timestamp.valueOf(thruDate).toInstant(), java.time.ZoneId.of('UTC'))"/>
-                <set field="queryParams.thruDate" from="thruZdtUTC.toString()"/>
-            </if>
-
-            <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
-                          in-map="[systemMessageTypeId:systemMessageTypeId, systemMessageRemoteId:systemMessageRemoteId, sendNow:true, messageText:org.moqui.impl.context.ContextJavaUtil.jacksonMapper.writeValueAsString(queryParams)]"
-                          out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
-        </actions>
-    </service>
-
     <service verb="generate" noun="ReturnedOrderIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
         <description>Generate returned orderIds feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -884,14 +884,14 @@ under the License.
                     queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
                 </script>
                 <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="appeasementIdsResponse"/>
-                <log level="warn" message="GENERATE APPEASEMENT SERVICE =================== ShopifyGraphqlRequest: ${appeasementIdsResponse}"/>
+                <log level="warn" message="GENERATE APPEASEMENT IDs SERVICE =================== ShopifyGraphqlRequest: ${appeasementIdsResponse}"/>
                 <if condition="!appeasementIdsResponse.response.orders.edges">
                     <return message="No Order with refunds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
                 </if>
                 <set field="nowDate" from="ec.user.nowTimestamp"/>
                 <set field="jsonFilePathRef" from="ec.resource.expand(systemMessage.receivePath, null, [contentRoot: ec.user.getPreference('mantle.content.root') ?: 'dbresource://datamanager', dateTime:ec.l10n.format(nowDate, 'yyyy-MM-dd-HH-mm-ss-SSS')], false)"/>
                 <set field="jsonFilePath" from="ec.resource.getLocationReference(jsonFilePathRef).getUri().getPath()"/>
-                <log level="warn" message="GENERATE RETURN ORDER SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
+                <log level="warn" message="GENERATE APPEASEMENT IDs SERVICE =================== jsonFilePath: ${jsonFilePath}"/>
                 <script>
                     try{
                     File feedFile = new File(jsonFilePath)
@@ -906,6 +906,7 @@ under the License.
 <!--                    <script>appeasementIds.addAll(order.refunds.id)</script>-->
 <!--                </iterate>-->
 
+                <log level="warn" message="appeasementIdsResponse.response.orders.edges=============================== ${appeasementIdsResponse.response.orders.edges}"/>
                 <set field="appeasementOrderIds" from="appeasementIdsResponse.response.orders.edges"/>
                 <iterate list="appeasementOrderIds" entry="appeasementOrderMap">
                     <iterate list="appeasementOrderMap.node.refunds" entry="refund">
@@ -925,10 +926,10 @@ under the License.
                 </script>
                 <log level="warn" message="appeasementOrderIds ==================== ${appeasementOrderIds}"/>
                 <if condition="relatedSystemMessageType">
-                    <log level="warn" message="GENERATE Appeasement ORDER SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
+                    <log level="warn" message="GENERATE Appeasement Ids SERVICE =================== is exist relatedSystemMessageType : ${relatedSystemMessageType}"/>
                     <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
-                    <log level="warn" message="GENERATE Appeasement ORDER SERVICE =================== serve call IncomingSystemMessage"/>
+                    <log level="warn" message="GENERATE Appeasement Ids SERVICE =================== serve call IncomingSystemMessage"/>
                 </if>
                 <set field="hasNextPage" from="appeasementIdsResponse.response.orders.pageInfo.hasNextPage"/>
                 <set field="cursor" from="appeasementIdsResponse.response.orders.pageInfo.endCursor"/>
@@ -1006,15 +1007,15 @@ under the License.
             </script>
             
             <iterate list="appeasementIds" entry="appeasementId">
-                <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#AppeasementDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, appeasementId:appeasementId]"
+                <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#AppeasementDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyRefundId:appeasementId.id]"
                               out-map="appeasementResponse" ignore-error="true" transaction="force-new"/>
+                <log level="warn" message="generate#appeasementsFeed,============= appeasementResponse ${appeasementResponse}"/>
                 <if condition="appeasementResponse">
-                    <log level="warn" message="generate#appeasementsFeed,============= appeasementResponse ${appeasementResponse}"/>
-                    <set field="appeasementMap" from="appeasementResponse"/>
+                    <set field="appeasementMap" from="appeasementResponse.appeasementResponse"/>
                     <script>
                         new ObjectMapper()
                         .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
-                        .writerWithDefaultPrettyPrinter().writeValue(jGenerator, appeasementResponse)
+                        .writerWithDefaultPrettyPrinter().writeValue(jGenerator, appeasementMap)
                     </script>
                 </if>
             </iterate>
@@ -1027,13 +1028,15 @@ under the License.
             </script>
 
             <if condition="relatedSystemMessageType">
+                <log level="warn" message="FINAL CALL ================= org.moqui.impl.SystemMessageServices.queue#SystemMessage======= \nsystemMessageTypeId:${relatedSystemMessageType.systemMessageTypeId}, systemMessageRemoteId:\n ${sendSmrId},
+                                       \n messageText:${jsonFilePathRef}, \n remoteMessageId: ${jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)}"/>
                 <service-call name="org.moqui.impl.SystemMessageServices.queue#SystemMessage"
                               in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, systemMessageRemoteId:sendSmrId,
-                                       messageText:jsonFilePathRef, remoteMessageId: jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
+                                       messageText:jsonFilePathRef, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1), sendNow:true]"
                               out-map="queueSystemMessageOut" ignore-error="true" transaction="force-new"/>
             </if>
 
-            <log level="error" message="FINAL CALL ================= queueSystemMessageOut: ${queueSystemMessageOut}"/>
+            <log level="error" message="FINAL CALL RESP================= queueSystemMessageOut: ${queueSystemMessageOut}"/>
         </actions>
     </service>
 

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -832,7 +832,7 @@ under the License.
     </service>
 
     <service verb="generate" noun="RefundIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
-        <description>Generate refund Ids feed.</description>
+        <description>Generate Refund Ids feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
         <actions>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>

--- a/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
+++ b/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml
@@ -831,8 +831,8 @@ under the License.
         </actions>
     </service>
 
-    <service verb="generate" noun="AppeasementIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
-        <description>Generate returned orderIds feed.</description>
+    <service verb="generate" noun="RefundIdsFeed" authenticate="anonymous-all" transaction-timeout="1800">
+        <description>Generate refund Ids feed.</description>
         <implements service="org.moqui.impl.SystemMessageServices.send#SystemMessage"/>
         <actions>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
@@ -863,8 +863,8 @@ under the License.
                 <script>
                     queryText = ec.resourceFacade.template(systemMessage.sendPath, "")
                 </script>
-                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="appeasementIdsResponse"/>
-                <if condition="!appeasementIdsResponse.response.orders.edges">
+                <service-call name="co.hotwax.shopify.common.ShopifyHelperServices.send#ShopifyGraphqlRequest" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, queryText:queryText]" out-map="refundOrdersResponse"/>
+                <if condition="!refundOrdersResponse.response.orders.edges">
                     <return message="No Order with refunds found between ${queryParams.fromDate} and ${queryParams.thruDate}"/>
                 </if>
                 <set field="nowDate" from="ec.user.nowTimestamp"/>
@@ -879,10 +879,9 @@ under the License.
                     JsonGenerator jGenerator = jfactory.createGenerator(pw)){
                         jGenerator.writeStartArray()
                 </script>
-                <set field="appeasementIds" from="[]"/>
-                <set field="appeasementOrderIds" from="appeasementIdsResponse.response.orders.edges"/>
-                <iterate list="appeasementOrderIds" entry="appeasementOrderMap">
-                    <iterate list="appeasementOrderMap.node.refunds" entry="refund">
+                <set field="refundOrders" from="refundOrdersResponse.response.orders.edges"/>
+                <iterate list="refundOrders" entry="refundOrder">
+                    <iterate list="refundOrder.node.refunds" entry="refund">
                         <script>
                             new ObjectMapper()
                             .setDateFormat(new java.text.SimpleDateFormat(System.getProperty("default_date_time_format")))
@@ -901,14 +900,14 @@ under the License.
                     <service-call name="org.moqui.impl.SystemMessageServices.receive#IncomingSystemMessage" in-map="[systemMessageTypeId:relatedSystemMessageType.systemMessageTypeId, messageText:jsonFilePathRef,
                               systemMessageRemoteId:systemMessage.systemMessageRemoteId, remoteMessageId:jsonFilePathRef.substring(jsonFilePathRef.lastIndexOf('/')+1)]" transaction="force-new" ignore-error="true"/>
                 </if>
-                <set field="hasNextPage" from="appeasementIdsResponse.response.orders.pageInfo.hasNextPage"/>
-                <set field="cursor" from="appeasementIdsResponse.response.orders.pageInfo.endCursor"/>
+                <set field="hasNextPage" from="refundOrdersResponse.response.orders.pageInfo.hasNextPage"/>
+                <set field="cursor" from="refundOrdersResponse.response.orders.pageInfo.endCursor"/>
             </while>
 
         </actions>
     </service>
 
-    <service verb="generate" noun="AppeasementsFeed" authenticate="anonymous-all" transaction-timeout="1800">
+    <service verb="generate" noun="RefundsFeed" authenticate="anonymous-all" transaction-timeout="1800">
         <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
         <actions>
             <entity-find-one entity-name="moqui.service.message.SystemMessageAndType" value-field="systemMessage"/>
@@ -943,10 +942,10 @@ under the License.
             </if>
 
             <set field="fileText" from="ec.resource.getLocationReference(systemMessage.messageText).getText()"/>
-            <set field="appeasementIds" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(fileText, List.class)"/>
+            <set field="refundIds" from="org.moqui.impl.context.ContextJavaUtil.jacksonMapper.readValue(fileText, List.class)"/>
 
-            <if condition="!appeasementIds">
-                <return type="warning" message="System message [${systemMessageId}] for Type [${systemMessage?.systemMessageTypeId}] has messageText [${systemMessage.messageText}], with AppeasementIdsFeed file having incorrect data and may contain null, not generating appeasements feed file."/>
+            <if condition="!refundIds">
+                <return type="warning" message="System message [${systemMessageId}] for Type [${systemMessage?.systemMessageTypeId}] has messageText [${systemMessage.messageText}], with refundIds file having incorrect data and may contain null, not generating refunds feed file."/>
             </if>
 
             <set field="nowDate" from="ec.user.nowTimestamp"/>
@@ -975,15 +974,15 @@ under the License.
                 jGenerator.writeStartArray()
             </script>
             
-            <iterate list="appeasementIds" entry="appeasementId">
-                <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#AppeasementDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, shopifyRefundId:appeasementId.id]"
-                              out-map="appeasementResponse" ignore-error="true" transaction="force-new"/>
-                <if condition="appeasementResponse">
-                    <set field="appeasementMap" from="appeasementResponse.appeasementResponse"/>
+            <iterate list="refundIds" entry="refundId">
+                <service-call name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundDetails" in-map="[systemMessageRemoteId:systemMessage.systemMessageRemoteId, refundId:refundId.id]"
+                              out-map="refundDetailsResponse" ignore-error="true" transaction="force-new"/>
+                <if condition="refundDetailsResponse">
+                    <set field="refundMap" from="refundDetailsResponse.refundDetail"/>
                     <script>
                         new ObjectMapper()
                         .setDateFormat(new java.text.SimpleDateFormat(System.getProperty('default_date_time_format')))
-                        .writerWithDefaultPrettyPrinter().writeValue(jGenerator, appeasementMap)
+                        .writerWithDefaultPrettyPrinter().writeValue(jGenerator, refundMap)
                     </script>
                 </if>
             </iterate>
@@ -991,7 +990,7 @@ under the License.
                         jGenerator.writeEndArray()
                     }
                 } catch (IOException e) {
-                    logger.error("Error preparing Appeasements Feed file", e)
+                    logger.error("Error preparing Refunds Feed file", e)
                 }
             </script>
 


### PR DESCRIPTION
Migrate the logic for processing Shopify refunds that are classified as appeasements (restock_type: no_restock) from OFBiz to Moqui. These represent customer refunds without inventory returns and must be recorded as returns of type APPEASEMENT in the new flow.

Issue: https://git.hotwax.co/commerce/shopify-oms-bridge/-/issues/31