### PR TITLE
Shopify shop remote

### DIFF
--- a/data/ShopifySetupSeedData.xml
+++ b/data/ShopifySetupSeedData.xml
@@ -20,9 +20,9 @@ under the License.
 
     <!-- Enumeration data for Shopify Shop Access Scope -->
     <moqui.basic.EnumerationType description="Shopify Shop Access Scope" enumTypeId="ShopifyShopAccessScope"/>
-    <moqui.basic.Enumeration description="Shopify Shop No Access" enumId="SHOP_NO_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
-    <moqui.basic.Enumeration description="Shopify Shop Read Only Access" enumId="SHOP_READ_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
-    <moqui.basic.Enumeration description="Shopify Shop Read and Write Access" enumId="SHOP_READ_WRITE_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
+    <moqui.basic.Enumeration description="Shopify Shop No Access" enumCode="SHOP_NO" enumId="SHOP_NO_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
+    <moqui.basic.Enumeration description="Shopify Shop Read Only Access" enumCode="SHOP_READ" enumId="SHOP_READ_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
+    <moqui.basic.Enumeration description="Shopify Shop Read and Write Access" enumCode="SHOP_READ_WRITE" enumId="SHOP_READ_WRITE_ACCESS" enumTypeId="ShopifyShopAccessScope"/>
 
     <!-- EnumerationType for Shopify system message type enum and relationship -->
     <moqui.basic.EnumerationType description="Shopify System Message Type Enum" enumTypeId="ShopifyMessageTypeEnum"/>

--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -89,14 +89,14 @@ under the License.
                 restClient.method(requestType)
                 restClient.uri(sendUrl)
 
-                //Check for basic auth, in case of private app system should use basic auth
-                if (systemMessageRemote.username && systemMessageRemote.password && !systemMessageRemote.authHeaderName) {
-                    restClient.basicAuth(systemMessageRemote.username, systemMessageRemote.password);
-                } else if (systemMessageRemote.sharedSecret) {
-                    restClient.addHeader(systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token',systemMessageRemote.sharedSecret);
-                } else {
-                    restClient.addHeader(systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token',systemMessageRemote.password);
+                def authHeaderName = systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token';
+                def accessToken = systemMessageRemote.sendSharedSecret;
+                //TODO: Fallback handling, this will be removed in upcoming releaes
+                if (systemMessageRemote.password) {
+                    accessToken = systemMessageRemote.password
                 }
+                restClient.addHeader(authHeaderName,accessToken);
+
                 restClient.contentType(contentType)
 
                 // Include parameters only if endPoint and parameters is not null

--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -58,7 +58,7 @@ under the License.
             </if>
 
             <!-- Preparing the shopify url -->
-            <if condition="endPoint">
+            <!--<if condition="endPoint">
                 <then>
                     <set field="remoteSendUrl" from="systemMessageRemote.sendUrl.endsWith('/') ? systemMessageRemote.sendUrl : systemMessageRemote.sendUrl+ '/'" />
                     <set field="sendUrl" from="ec.resourceFacade.expand(remoteSendUrl, null, ['shopifyApiVersion': System.getProperty('shopify_api_version')])"/>
@@ -67,18 +67,27 @@ under the License.
                 <else-if condition="url">
                     <set field="shopifyUrl" from="url"/>
                 </else-if>
-            </if>
+            </if>-->
 
             <script><![CDATA[
                 import org.moqui.util.RestClient
+                import co.hotwax.shopify.util.ShopifyHelper
 
-                //shopifyUrl = ec.resourceFacade.expand(shopifyUrl, null, ["shopifyApiVersion": System.getProperty("shopify_api_version")])
+                def sendUrl = ''
+                if (endPoint) {
+                   def apiUrl = new StringBuilder(ShopifyHelper.sanitizeUrl(systemMessageRemote.sendUrl, true))
+                   apiUrl.append('/admin/api/').append(System.getProperty('shopify_api_version')).append(endPoint)
+                   sendUrl = apiUrl.toString()
+                } else if (url) {
+                    sendUrl = url
+                }
+
                 // Prepare RestClient and call Shopify API
                 RestClient restClient = ec.service.rest()
                 restClient.timeoutRetry(true);
                 restClient.retry(2, 4);
                 restClient.method(requestType)
-                restClient.uri(shopifyUrl)
+                restClient.uri(sendUrl)
 
                 //Check for basic auth, in case of private app system should use basic auth
                 if (systemMessageRemote.username && systemMessageRemote.password && !systemMessageRemote.authHeaderName) {
@@ -187,29 +196,32 @@ under the License.
                 <return error="true" message="Cannot post graphQL mutation, only read access is enabled for Shopify with systemMessageRemoteId, ${systemMessageRemoteId}."/>
             </if>
 
-            <set field="remoteSendUrl" from="systemMessageRemote.sendUrl.endsWith('/') ? systemMessageRemote.sendUrl : systemMessageRemote.sendUrl+ '/'" />
+            <!--<set field="remoteSendUrl" from="systemMessageRemote.sendUrl.endsWith('/') ? systemMessageRemote.sendUrl : systemMessageRemote.sendUrl+ '/'" />
             <set field="sendUrl" from="ec.resourceFacade.expand(remoteSendUrl, null, ['shopifyApiVersion': System.getProperty('shopify_api_version')])"/>
-            <set field="shopifyUrl" from="sendUrl + 'graphql.json'"/>
+            <set field="shopifyUrl" from="sendUrl + 'graphql.json'"/>-->
 
             <script><![CDATA[
                 import org.moqui.util.RestClient
+                import co.hotwax.shopify.util.ShopifyHelper
 
-                //shopifyUrl = ec.resourceFacade.expand(shopifyUrl, null, ["shopifyApiVersion": System.getProperty("shopify_api_version")])
+                def sendUrl = new StringBuilder(ShopifyHelper.sanitizeUrl(systemMessageRemote.sendUrl, true))
+                sendUrl.append('/admin/api/').append(System.getProperty('shopify_api_version')).append("/graphql.json")
+
+
                 // Prepare RestClient and call Shopify API
                 RestClient restClient = ec.service.rest()
                 restClient.timeoutRetry(true);
                 restClient.retry(2, 4);
                 restClient.method("POST")
-                restClient.uri(shopifyUrl)
-
-                //Check for basic auth, in case of private app system should use basic auth
-                if (systemMessageRemote.username && systemMessageRemote.password && !systemMessageRemote.authHeaderName) {
-                    restClient.basicAuth(systemMessageRemote.username, systemMessageRemote.password);
-                } else if (systemMessageRemote.sharedSecret) {
-                    restClient.addHeader(systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token',systemMessageRemote.sharedSecret);
-                } else {
-                    restClient.addHeader(systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token',systemMessageRemote.password);
+                restClient.uri(sendUrl.toString())
+                def authHeaderName = systemMessageRemote.authHeaderName?:'X-Shopify-Access-Token';
+                def accessToken = systemMessageRemote.sendSharedSecret;
+                //TODO: Fallback handling, this will be removed in upcoming releaes
+                if (systemMessageRemote.password) {
+                    accessToken = systemMessageRemote.password
                 }
+                restClient.addHeader(authHeaderName,accessToken);
+
                 restClient.contentType("application/json")
 
                 restClient.jsonObject([query:queryText, variables:variables])
@@ -233,9 +245,9 @@ under the License.
             </if>
             <set field="response" from="gqlResponse.data"/>
             <if condition="gqlResponse.extensions &amp;&amp; gqlResponse.extensions.cost">
-                <log level="info" message="GraphQL requested query cost: ${gqlResponse.extensions.cost.requestedQueryCost}"/>
-                <log level="info" message="GraphQL actual query cost: ${gqlResponse.extensions.cost.actualQueryCost}"/>
-                <log level="info" message="GraphQL available limit: ${gqlResponse.extensions.cost.throttleStatus.currentlyAvailable}"/>
+                <log level="debug" message="GraphQL requested query cost: ${gqlResponse.extensions.cost.requestedQueryCost}"/>
+                <log level="debug" message="GraphQL actual query cost: ${gqlResponse.extensions.cost.actualQueryCost}"/>
+                <log level="debug" message="GraphQL available limit: ${gqlResponse.extensions.cost.throttleStatus.currentlyAvailable}"/>
             </if>
         </actions>
     </service>

--- a/src/main/groovy/co/hotwax/shopify/util/ShopifyHelper.groovy
+++ b/src/main/groovy/co/hotwax/shopify/util/ShopifyHelper.groovy
@@ -1,0 +1,28 @@
+package co.hotwax.shopify.util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class ShopifyHelper {
+    protected final static Logger logger = LoggerFactory.getLogger(ShopifyHelper.class)
+
+    public static String resolveShopifyGid(String gid) {
+        if (!gid) return null
+        return gid.substring(gid.lastIndexOf('/')+1)
+    }
+    static String sanitizeUrl(String url, boolean secure) {
+        if (!url) return null
+
+        // Trim and remove trailing slashes
+        url = url.trim().replaceAll('/+$', '')
+
+        // Extract base domain (strip path/query)
+        def matcher = url =~ /^(https?:\/\/)?([^\/]+)/
+        def baseUrl = matcher ? matcher[0][2] : url
+
+        // Return with https scheme
+
+        return secure?"https://${baseUrl}":baseUrl
+    }
+
+}


### PR DESCRIPTION
- Updated integration logic to use SystemMessageRemote.sendSharedSecret as the primary access token for outbound requests.
- Added fallback handling to support SystemMessageRemote.password as the access token for backward compatibility.
- Enhanced webhook filter logic to validate incoming requests using both:
  - sharedSecret (new)
  - oldSharedSecret (previous key for smooth rotation)
- Legacy compatibility logic retained: In legacy setups, the secret key was stored in sendSharedSecret. Fallback handling ensures compatibility with those systems until fully migrated.
