### PR TITLE
Corrected: Endpoint preparation logic in the send#ShopifyRequest service

### DIFF
--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -116,9 +116,7 @@ under the License.
                 if (requestBody != null) {
                     restClient.jsonObject(requestBody)
                 }
-                try {
-                ec.logger.info("Chinmay Sharma: "+ accessToken + " " + authHeaderName);
-                ec.logger.info("Shopify Request: " + sendUrl + " with parameters: " + parameters + " and requestBody: " + requestBody);
+                try {                
                     RestClient.RestResponse restResponse = restClient.call()
                     response = restResponse.jsonObject()
                     statusCode = restResponse.getStatusCode()

--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -75,6 +75,9 @@ under the License.
 
                 def sendUrl = ''
                 if (endPoint) {
+                   if (!endPoint.startsWith('/')) {
+                       endPoint = '/' + endPoint
+                   }
                    def apiUrl = new StringBuilder(ShopifyHelper.sanitizeUrl(systemMessageRemote.sendUrl, true))
                    apiUrl.append('/admin/api/').append(System.getProperty('shopify_api_version')).append(endPoint)
                    sendUrl = apiUrl.toString()
@@ -114,6 +117,8 @@ under the License.
                     restClient.jsonObject(requestBody)
                 }
                 try {
+                ec.logger.info("Chinmay Sharma: "+ accessToken + " " + authHeaderName);
+                ec.logger.info("Shopify Request: " + sendUrl + " with parameters: " + parameters + " and requestBody: " + requestBody);
                     RestClient.RestResponse restResponse = restClient.call()
                     response = restResponse.jsonObject()
                     statusCode = restResponse.getStatusCode()

--- a/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
+++ b/service/co/hotwax/shopify/common/ShopifyHelperServices.xml
@@ -116,7 +116,7 @@ under the License.
                 if (requestBody != null) {
                     restClient.jsonObject(requestBody)
                 }
-                try {                
+                try {
                     RestClient.RestResponse restResponse = restClient.call()
                     response = restResponse.jsonObject()
                     statusCode = restResponse.getStatusCode()


### PR DESCRIPTION
- The URL for endpoints that don't start with '/' was being built incorrectly. Appended '/' before the endpoint if it doesn't already exists.