### PR TITLE
Updated: purge#OldSystemMessages service to fetch the system messages in descending order of initDate

### DIFF
--- a/service/co/hotwax/impl/SystemMessageServices.xml
+++ b/service/co/hotwax/impl/SystemMessageServices.xml
@@ -34,7 +34,7 @@ under the License.
                 <econdition field-name="initDate" operator="less" from="purgeDate"/>
                 <econdition field-name="systemMessageTypeId" operator="equals" from="systemMessageTypeId" ignore-if-empty="true"/>
                 <econdition field-name="parentTypeId" operator="equals" from="parentSystemMessageTypeId" ignore-if-empty="true"/>
-                <order-by field-name="initDate"/>
+                <order-by field-name="-initDate"/>
                 <use-iterator/>
             </entity-find>
             <iterate list="systemMessages" entry="systemMessage">


### PR DESCRIPTION
1. Updated purge#OldSystemMessages service to fetch the system message in descending order of initDate.