### PR TITLE
Improvement: Define rest endpoint to expose the get#RefundDetails service

### DIFF
--- a/service/shopify.rest.xml
+++ b/service/shopify.rest.xml
@@ -36,6 +36,11 @@ under the License.
             </method>
         </resource>
     </resource>
+    <resource name="return" require-authentication="anonymous-all">
+        <resource name="refund" require-authentication="anonymous-all">
+            <method type="get"><service name="co.hotwax.shopify.return.ShopifyReturnServices.get#RefundDetails"/></method>
+        </resource>
+    </resource>
     <resource name="bulk" require-authentication="anonymous-all">
         <resource name="query" require-authentication="anonymous-all">
             <method type="post">


### PR DESCRIPTION
This adds the api endpoint to fetch the Shopify refund details by running the service `get#RefundDetails`. This improvement is required for the approach to fix this issue https://git.hotwax.co/commerce/deliveries/gorjana/-/issues/18. 

**Use case:**
In loop returns integration, the return against the exchange order is referenced to the original order for which the exchange order was created earlier. So this endpoint is used in the loop integration to get the order ID from the Shopify refund object (getting the Shopify Refund ID from the loop's refund object).

**Endpoint:** `https://<instance.name>:8080/rest/s1/shopify/return/refund`.